### PR TITLE
Rename format identifier from librus to vulcan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Klassroom generates HTML presentations for Polish parent-teacher meetings from school grade XLSX exports (Librus Synergia, later Vulcan UONET+).
+Klassroom generates HTML presentations for Polish parent-teacher meetings from school grade XLSX exports (Vulcan UONET+).
 
 ## Critical Constraints
 
@@ -29,9 +29,9 @@ Adheres to following principles:
 
 ## Domain Knowledge
 
-### Librus Synergia XLSX Export Format
+### Vulcan UONET+ XLSX Export Format
 
-Librus Synergia's "additional internal documentation" XLSX export contains 6 Polish-named sheets. Format detection requires at least 4 of these sheets to be present:
+Vulcan UONET+ "additional internal documentation" XLSX export contains 6 Polish-named sheets. Format detection requires at least 4 of these sheets to be present:
 
 | Sheet Name | Purpose | Used by Parser |
 |------------|---------|----------------|
@@ -63,6 +63,6 @@ Librus Synergia's "additional internal documentation" XLSX export contains 6 Pol
 
 Polish behavior grades map: wzorowe→exemplary, bardzo dobre→veryGood, dobre→good, poprawne→acceptable, nieodpowiednie→inappropriate, naganne→reprehensible.
 
-### Future: Vulcan UONET+ Support
+### Future: Librus Synergia Support
 
-Vulcan UONET+ exports are not yet supported. They use different sheet structures and terminology. Format detection will reject non-Librus files with a helpful error message.
+Librus Synergia exports are not yet supported. We have no verified sample of the Librus format - it may or may not use the same sheet structure as Vulcan UONET+. If you have a Librus Synergia export file, please file an issue to help us add support.

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -14,11 +14,11 @@ vi.mock("node:fs/promises", () => ({
 
 vi.mock("@klassroom/core", () => ({
   VERSION: "0.0.0",
-  parseLibrusXlsx: vi.fn(),
+  parseVulcanXlsx: vi.fn(),
   generatePresentation: vi.fn(),
 }));
 
-import { parseLibrusXlsx, generatePresentation } from "@klassroom/core";
+import { parseVulcanXlsx, generatePresentation } from "@klassroom/core";
 import { generate } from "./cli.js";
 
 describe("generate function", () => {
@@ -50,7 +50,7 @@ describe("generate function", () => {
 
   it("generates HTML from valid XLSX", async () => {
     vi.mocked(existsSync).mockReturnValue(true);
-    vi.mocked(parseLibrusXlsx).mockReturnValue({
+    vi.mocked(parseVulcanXlsx).mockReturnValue({
       metadata: {
         className: "5b",
         period: "2024/2025 - Semestr 1" as import("@klassroom/core").ClassPeriod,
@@ -65,7 +65,7 @@ describe("generate function", () => {
 
     expect(result.success).toBe(true);
     expect(result.outputPath).toBe("/path/to/klasa-5b.html");
-    expect(parseLibrusXlsx).toHaveBeenCalledWith("/path/to/klasa-5b.xlsx");
+    expect(parseVulcanXlsx).toHaveBeenCalledWith("/path/to/klasa-5b.xlsx");
     expect(generatePresentation).toHaveBeenCalled();
     expect(writeFile).toHaveBeenCalledWith(
       "/path/to/klasa-5b.html",
@@ -76,7 +76,7 @@ describe("generate function", () => {
 
   it("returns error for parser failures", async () => {
     vi.mocked(existsSync).mockReturnValue(true);
-    vi.mocked(parseLibrusXlsx).mockImplementation(() => {
+    vi.mocked(parseVulcanXlsx).mockImplementation(() => {
       throw new Error("Unrecognized XLSX format");
     });
 
@@ -88,7 +88,7 @@ describe("generate function", () => {
 
   it("returns error for generator failures", async () => {
     vi.mocked(existsSync).mockReturnValue(true);
-    vi.mocked(parseLibrusXlsx).mockReturnValue({
+    vi.mocked(parseVulcanXlsx).mockReturnValue({
       metadata: {
         className: "5b",
         period: "2024/2025 - Semestr 1" as import("@klassroom/core").ClassPeriod,
@@ -106,7 +106,7 @@ describe("generate function", () => {
 
   it("returns error for file write failures", async () => {
     vi.mocked(existsSync).mockReturnValue(true);
-    vi.mocked(parseLibrusXlsx).mockReturnValue({
+    vi.mocked(parseVulcanXlsx).mockReturnValue({
       metadata: {
         className: "5b",
         period: "2024/2025 - Semestr 1" as import("@klassroom/core").ClassPeriod,
@@ -125,7 +125,7 @@ describe("generate function", () => {
 
   it("handles .XLSX extension (case insensitive)", async () => {
     vi.mocked(existsSync).mockReturnValue(true);
-    vi.mocked(parseLibrusXlsx).mockReturnValue({
+    vi.mocked(parseVulcanXlsx).mockReturnValue({
       metadata: {
         className: "5b",
         period: "2024/2025 - Semestr 1" as import("@klassroom/core").ClassPeriod,

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -6,7 +6,7 @@ import { basename, dirname, extname, join } from "node:path";
 import { Command } from "commander";
 import {
   VERSION,
-  parseLibrusXlsx,
+  parseVulcanXlsx,
   generatePresentation,
 } from "@klassroom/core";
 
@@ -32,7 +32,7 @@ export async function generate(xlsxPath: string): Promise<GenerateResult> {
 
   try {
     // Parse XLSX
-    const classData = parseLibrusXlsx(xlsxPath);
+    const classData = parseVulcanXlsx(xlsxPath);
 
     // Generate HTML
     const html = await generatePresentation(classData);
@@ -54,13 +54,13 @@ export function createProgram(): Command {
 
   program
     .name("klassroom")
-    .description("Generuje prezentacje HTML z eksportów ocen Librus Synergia")
+    .description("Generuje prezentacje HTML z eksportów ocen Vulcan UONET+")
     .version(VERSION);
 
   program
     .command("generate")
     .description("Generuje prezentację HTML z pliku XLSX")
-    .argument("<xlsx-path>", "Ścieżka do pliku XLSX z eksportu Librus")
+    .argument("<xlsx-path>", "Ścieżka do pliku XLSX z eksportu Vulcan UONET+")
     .action(async (xlsxPath: string) => {
       const result = await generate(xlsxPath);
 

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -23,11 +23,11 @@ import {
  * GDPR: Output uses student numbers only, never names.
  * All text is in Polish.
  *
- * @param data - Parsed class data from Librus XLSX export
+ * @param data - Parsed class data from Vulcan XLSX export
  * @returns Promise resolving to complete HTML string
  *
  * @example
- * const data = parseLibrusXlsx("grades.xlsx");
+ * const data = parseVulcanXlsx("grades.xlsx");
  * const html = await generatePresentation(data);
  * fs.writeFileSync("presentation.html", html);
  */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,7 +32,7 @@ export {
 export { BEHAVIOR_GRADES, POLISH_TO_BEHAVIOR } from "./types/index.js";
 
 // Parser
-export { parseLibrusXlsx, detectFormat } from "./parser/index.js";
+export { parseVulcanXlsx, detectFormat } from "./parser/index.js";
 export type { DetectedFormat } from "./parser/index.js";
 
 // Analytics

--- a/packages/core/src/parser/index.test.ts
+++ b/packages/core/src/parser/index.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as XLSX from "xlsx";
-import { parseLibrusXlsx, detectFormat } from "./index.js";
+import { parseVulcanXlsx, detectFormat } from "./index.js";
 import { parseGradesSheet } from "./sheets/grades.js";
 import { parseAveragesSheet } from "./sheets/averages.js";
 import { parseMetadataSheet } from "./sheets/metadata.js";
@@ -18,7 +18,7 @@ vi.mock("xlsx", () => ({
 }));
 
 describe("detectFormat", () => {
-  it("detects Librus format when all 6 sheets present", () => {
+  it("detects Vulcan format when all 6 sheets present", () => {
     const sheetNames = [
       "Okres klasyfikacyjny",
       "Dodatkowe informacje 1",
@@ -30,12 +30,12 @@ describe("detectFormat", () => {
 
     const result = detectFormat(sheetNames);
 
-    expect(result.format).toBe("librus");
+    expect(result.format).toBe("vulcan");
     expect(result.matchedSheets).toHaveLength(6);
     expect(result.missingSheets).toHaveLength(0);
   });
 
-  it("detects Librus format when 4+ sheets present", () => {
+  it("detects Vulcan format when 4+ sheets present", () => {
     const sheetNames = [
       "Okres klasyfikacyjny",
       "Dodatkowe informacje 1",
@@ -45,7 +45,7 @@ describe("detectFormat", () => {
 
     const result = detectFormat(sheetNames);
 
-    expect(result.format).toBe("librus");
+    expect(result.format).toBe("vulcan");
     expect(result.matchedSheets).toHaveLength(4);
     expect(result.missingSheets).toHaveLength(2);
   });
@@ -70,7 +70,7 @@ describe("detectFormat", () => {
   });
 });
 
-describe("parseLibrusXlsx", () => {
+describe("parseVulcanXlsx", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
@@ -82,7 +82,7 @@ describe("parseLibrusXlsx", () => {
   it("throws error when file not found", () => {
     vi.mocked(fs.existsSync).mockReturnValue(false);
 
-    expect(() => parseLibrusXlsx("/path/to/missing.xlsx")).toThrow(
+    expect(() => parseVulcanXlsx("/path/to/missing.xlsx")).toThrow(
       "File not found: /path/to/missing.xlsx"
     );
   });
@@ -95,12 +95,12 @@ describe("parseLibrusXlsx", () => {
       Sheets: {},
     } as XLSX.WorkBook);
 
-    expect(() => parseLibrusXlsx("/path/to/file.xlsx")).toThrow(
-      /Unrecognized XLSX format.*Vulcan UONET\+ and other formats are not yet supported/
+    expect(() => parseVulcanXlsx("/path/to/file.xlsx")).toThrow(
+      /Unrecognized XLSX format.*Other formats not yet supported/
     );
   });
 
-  it("throws error when required sheet is missing from Librus file", () => {
+  it("throws error when required sheet is missing from Vulcan file", () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from("mock"));
     // Provide 4 sheets to pass format detection, but missing "Dodatkowe informacje 1"
@@ -114,7 +114,7 @@ describe("parseLibrusXlsx", () => {
       Sheets: {},
     } as XLSX.WorkBook);
 
-    expect(() => parseLibrusXlsx("/path/to/file.xlsx")).toThrow(
+    expect(() => parseVulcanXlsx("/path/to/file.xlsx")).toThrow(
       /Missing required sheet: Dodatkowe informacje 1/
     );
   });
@@ -123,7 +123,7 @@ describe("parseLibrusXlsx", () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue(Buffer.from("mock"));
 
-    // Mock sheet data in Librus format
+    // Mock sheet data in Vulcan format
     // Grades sheet: Row 0 = headers, Row 1 = subjects, Row 2 = separator, Row 3+ = data
     const gradesSheetData = [
       ["Nr w dzienniku", "Uczeń", "Zachowanie", "Nazwa przedmiotu"],
@@ -145,7 +145,7 @@ describe("parseLibrusXlsx", () => {
       ["Oddział", "3A", "Wychowawca", null, null, "Maria Wiśniewska"],
     ];
 
-    // Mock workbook with all 6 Librus sheets (format detection requires 4+)
+    // Mock workbook with all 6 Vulcan sheets (format detection requires 4+)
     vi.mocked(XLSX.read).mockReturnValue({
       SheetNames: [
         "Okres klasyfikacyjny",
@@ -172,7 +172,7 @@ describe("parseLibrusXlsx", () => {
       .mockReturnValueOnce(gradesSheetData)
       .mockReturnValueOnce(averagesSheetData);
 
-    const result = parseLibrusXlsx("/path/to/file.xlsx");
+    const result = parseVulcanXlsx("/path/to/file.xlsx");
 
     // Verify metadata
     expect(result.metadata.className).toBe("3A");
@@ -211,7 +211,7 @@ describe("parseLibrusXlsx", () => {
 
 describe("parseGradesSheet", () => {
   it("parses grades matrix with behavior correctly", () => {
-    // Librus format: Row 0 = headers, Row 1 = subjects, Row 2 = separator, Row 3+ = data
+    // Vulcan format: Row 0 = headers, Row 1 = subjects, Row 2 = separator, Row 3+ = data
     const sheetData = [
       ["Nr w dzienniku", "Uczeń", "Zachowanie", "Nazwa przedmiotu"],
       [null, null, null, "Matematyka", "Polski"],
@@ -263,7 +263,7 @@ describe("parseGradesSheet", () => {
 
 describe("parseAveragesSheet", () => {
   it("parses student averages correctly", () => {
-    // Librus format: [number, name, average]
+    // Vulcan format: [number, name, average]
     const sheetData = [
       ["Numer w dzienniku", "Dane ucznia", "Średnia"],
       [1, "Jan Kowalski", 4.5],
@@ -300,8 +300,8 @@ describe("parseAveragesSheet", () => {
 });
 
 describe("parseMetadataSheet", () => {
-  it("parses class metadata correctly from Librus format", () => {
-    // Real Librus format:
+  it("parses class metadata correctly from Vulcan format", () => {
+    // Real Vulcan format:
     // Row 0: Title with period info
     // Row 1: Horizontal form with Oddział and Wychowawca
     const sheetData = [

--- a/packages/core/src/parser/index.ts
+++ b/packages/core/src/parser/index.ts
@@ -7,10 +7,10 @@ import { parseAveragesSheet } from "./sheets/averages.js";
 import { parseMetadataSheet } from "./sheets/metadata.js";
 
 /**
- * All 6 sheet names that appear in Librus Synergia XLSX exports.
+ * All 6 sheet names that appear in Vulcan UONET+ XLSX exports.
  * Used for format detection/validation.
  */
-const LIBRUS_SHEET_NAMES = [
+const VULCAN_SHEET_NAMES = [
   "Okres klasyfikacyjny",
   "Dodatkowe informacje 1",
   "Średnia uczniów",
@@ -20,7 +20,7 @@ const LIBRUS_SHEET_NAMES = [
 ] as const;
 
 /**
- * Sheets required for parsing (subset of LIBRUS_SHEET_NAMES).
+ * Sheets required for parsing (subset of VULCAN_SHEET_NAMES).
  * Note: Behavior is embedded in the grades sheet column, not parsed from "Zachowanie" sheet.
  */
 const REQUIRED_SHEETS = {
@@ -32,7 +32,7 @@ const REQUIRED_SHEETS = {
 /**
  * Detected file format from sheet name analysis.
  */
-export type DetectedFormat = "librus" | "unknown";
+export type DetectedFormat = "vulcan" | "unknown";
 
 /**
  * Detects the format of an XLSX file based on sheet names.
@@ -46,19 +46,19 @@ export function detectFormat(sheetNames: string[]): {
   missingSheets: string[];
 } {
   const sheetSet = new Set(sheetNames);
-  const matchedSheets = LIBRUS_SHEET_NAMES.filter((name) => sheetSet.has(name));
-  const missingSheets = LIBRUS_SHEET_NAMES.filter((name) => !sheetSet.has(name));
+  const matchedSheets = VULCAN_SHEET_NAMES.filter((name) => sheetSet.has(name));
+  const missingSheets = VULCAN_SHEET_NAMES.filter((name) => !sheetSet.has(name));
 
-  // Consider it Librus format if at least 4 of 6 expected sheets are present
-  const format: DetectedFormat = matchedSheets.length >= 4 ? "librus" : "unknown";
+  // Consider it Vulcan format if at least 4 of 6 expected sheets are present
+  const format: DetectedFormat = matchedSheets.length >= 4 ? "vulcan" : "unknown";
 
   return { format, matchedSheets, missingSheets };
 }
 
 /**
- * Parses a Librus Synergia XLSX grade export into ClassData.
+ * Parses a Vulcan UONET+ XLSX grade export into ClassData.
  *
- * Supports XLSX files exported from Librus Synergia's "additional internal documentation"
+ * Supports XLSX files exported from Vulcan UONET+ "additional internal documentation"
  * export option. The format is identified by 6 characteristic Polish sheet names.
  *
  * Note: This function uses synchronous file I/O (fs.readFileSync).
@@ -69,11 +69,11 @@ export function detectFormat(sheetNames: string[]): {
  * @throws Error if file not found, unrecognized format, missing required sheets, or invalid structure
  *
  * @example
- * const data = parseLibrusXlsx("./grades.xlsx");
+ * const data = parseVulcanXlsx("./grades.xlsx");
  * console.log(data.metadata.className); // "3A"
  * console.log(data.students[0].number); // 1
  */
-export function parseLibrusXlsx(filePath: string): ClassData {
+export function parseVulcanXlsx(filePath: string): ClassData {
   // Check file exists
   if (!fs.existsSync(filePath)) {
     throw new Error(`File not found: ${filePath}`);
@@ -89,9 +89,9 @@ export function parseLibrusXlsx(filePath: string): ClassData {
   if (format === "unknown") {
     const foundSheets = workbook.SheetNames.join(", ");
     throw new Error(
-      `Unrecognized XLSX format. Expected Librus Synergia export with sheets: ${LIBRUS_SHEET_NAMES.join(", ")}. ` +
+      `Unrecognized XLSX format. Expected Vulcan UONET+ export with sheets: ${VULCAN_SHEET_NAMES.join(", ")}. ` +
         `Found sheets: ${foundSheets}. ` +
-        `This parser only supports Librus Synergia exports. Vulcan UONET+ and other formats are not yet supported.`
+        `This parser only supports Vulcan UONET+ exports. Other formats not yet supported - please file an issue.`
     );
   }
 
@@ -100,7 +100,7 @@ export function parseLibrusXlsx(filePath: string): ClassData {
     if (!workbook.SheetNames.includes(sheetName)) {
       throw new Error(
         `Missing required sheet: ${sheetName}. ` +
-          `Matched ${matchedSheets.length}/6 Librus sheets. Missing: ${missingSheets.join(", ")}`
+          `Matched ${matchedSheets.length}/6 Vulcan sheets. Missing: ${missingSheets.join(", ")}`
       );
     }
   }

--- a/packages/core/src/parser/sheets/averages.ts
+++ b/packages/core/src/parser/sheets/averages.ts
@@ -4,7 +4,7 @@ import * as XLSX from "xlsx";
 /**
  * Parses the "Średnia uczniów" (student averages) sheet.
  *
- * Librus format:
+ * Vulcan format:
  * - Row 0: Headers ["Numer w dzienniku", "Dane ucznia", "Średnia"]
  * - Row 1+: Student data [number, name, average]
  *

--- a/packages/core/src/parser/sheets/grades.ts
+++ b/packages/core/src/parser/sheets/grades.ts
@@ -16,7 +16,7 @@ export interface GradesRow {
 /**
  * Parses the "Okres klasyfikacyjny" (grades matrix) sheet.
  *
- * Librus format:
+ * Vulcan format:
  * - Row 0: Headers ["Nr w dzienniku", "Uczeń", "Zachowanie", "Nazwa przedmiotu", ...]
  * - Row 1: Subject names [null, null, null, "Religia", "Język polski", ...]
  * - Row 2: Empty separator row

--- a/packages/core/src/parser/sheets/metadata.ts
+++ b/packages/core/src/parser/sheets/metadata.ts
@@ -5,7 +5,7 @@ import { classPeriod, type ClassMetadata } from "../../types/index.js";
 /**
  * Parses the "Dodatkowe informacje 1" (class metadata) sheet.
  *
- * Handles Librus export format:
+ * Handles Vulcan export format:
  * - Row 0: Title with period info (e.g., "Dodatkowe informacje dla 1 semestru w roku szkolnym 2025/2026")
  * - Row 1: Contains "Oddział" (class) and "Wychowawca" (teacher) in horizontal form layout
  *

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -25,7 +25,7 @@ export type ClassPeriod = string & { readonly __brand: "ClassPeriod" };
 
 /**
  * Creates a type-safe ClassPeriod from a plain string.
- * @param period - The classification period string from Librus export
+ * @param period - The classification period string from Vulcan export
  * @returns A branded ClassPeriod
  * @throws Error if period is empty
  */
@@ -173,7 +173,7 @@ export function calculateAttendancePercentage(
 /**
  * Internal student representation with full data including name.
  * Used during XLSX parsing to correlate data across sheets (students are
- * referenced by name in Librus exports). Must be stripped to {@link Student}
+ * referenced by name in Vulcan exports). Must be stripped to {@link Student}
  * before returning from any public API.
  *
  * @internal Package-internal type. NOT exported from barrel - import directly
@@ -230,7 +230,7 @@ export interface Student {
 }
 
 /**
- * Class metadata from the Librus export.
+ * Class metadata from the Vulcan export.
  */
 export interface ClassMetadata {
   /** Class name/identifier (e.g., "3A", "2B") */


### PR DESCRIPTION
## Summary
- Renames `parseLibrusXlsx()` to `parseVulcanXlsx()` - parser was incorrectly labeled
- Changes `DetectedFormat` from `"librus"` to `"vulcan"` 
- Updates all error messages and documentation to reference Vulcan UONET+

Fixes #31

## Test plan
- [x] All 142 existing tests pass
- [x] Build completes successfully
- [x] No remaining `parseLibrusXlsx` references in codebase
- [x] AGENTS.md accurately describes Vulcan format and notes Librus as future/unverified

🤖 Generated with [Claude Code](https://claude.com/claude-code)