### PR TITLE
feat: add subject enrollment statistics slide

### DIFF
--- a/packages/core/src/generator/index.test.ts
+++ b/packages/core/src/generator/index.test.ts
@@ -9,7 +9,13 @@ function createClassData(
     num: number;
     grades?: Array<{ subject: string; value: string | null }>;
     average?: number;
-    behavior?: "exemplary" | "veryGood" | "good" | "acceptable" | "inappropriate" | "reprehensible";
+    behavior?:
+      | "exemplary"
+      | "veryGood"
+      | "good"
+      | "acceptable"
+      | "inappropriate"
+      | "reprehensible";
   }>,
   metadata?: Partial<ClassData["metadata"]>,
   classAttendance?: ClassData["classAttendance"]
@@ -36,7 +42,7 @@ describe("generatePresentation", () => {
     const html = await generatePresentation(data);
 
     expect(html).toMatch(/^<!DOCTYPE html>/);
-    expect(html).toContain("<html lang=\"pl\">");
+    expect(html).toContain('<html lang="pl">');
     expect(html).toContain("</html>");
   });
 
@@ -224,8 +230,8 @@ describe("generatePresentation", () => {
     it("renders top students slide when students have 4.75+ average", async () => {
       const data = createClassData([
         { num: 1, average: 5.25 },
-        { num: 2, average: 4.80 },
-        { num: 3, average: 4.50 }, // below threshold
+        { num: 2, average: 4.8 },
+        { num: 3, average: 4.5 }, // below threshold
       ]);
 
       const html = await generatePresentation(data);
@@ -237,8 +243,8 @@ describe("generatePresentation", () => {
 
     it("skips slide when no students meet threshold", async () => {
       const data = createClassData([
-        { num: 1, average: 4.50 },
-        { num: 2, average: 4.00 },
+        { num: 1, average: 4.5 },
+        { num: 2, average: 4.0 },
       ]);
 
       const html = await generatePresentation(data);
@@ -248,10 +254,10 @@ describe("generatePresentation", () => {
 
     it("sorts by average descending, then by number ascending", async () => {
       const data = createClassData([
-        { num: 3, average: 4.80 },
-        { num: 1, average: 5.00 },
-        { num: 5, average: 4.80 }, // tied with num 3
-        { num: 2, average: 4.90 },
+        { num: 3, average: 4.8 },
+        { num: 1, average: 5.0 },
+        { num: 5, average: 4.8 }, // tied with num 3
+        { num: 2, average: 4.9 },
       ]);
 
       const html = await generatePresentation(data);
@@ -269,22 +275,20 @@ describe("generatePresentation", () => {
     });
 
     it("displays only student numbers, never names (GDPR)", async () => {
-      const data = createClassData([
-        { num: 7, average: 5.00 },
-      ]);
+      const data = createClassData([{ num: 7, average: 5.0 }]);
 
       const html = await generatePresentation(data);
 
       expect(html).toContain("Numer ucznia");
       expect(html).toContain("<td>7</td>");
       // The slide should not have any name-related columns
-      expect(html).not.toMatch(/<th[^>]*>.*(?:Imię|Nazwisko|Uczeń|Name).*<\/th>/i);
+      expect(html).not.toMatch(
+        /<th[^>]*>.*(?:Imię|Nazwisko|Uczeń|Name).*<\/th>/i
+      );
     });
 
     it("formats average with comma as decimal separator", async () => {
-      const data = createClassData([
-        { num: 1, average: 5.25 },
-      ]);
+      const data = createClassData([{ num: 1, average: 5.25 }]);
 
       const html = await generatePresentation(data);
 
@@ -347,11 +351,10 @@ describe("generatePresentation", () => {
 
   describe("attendance slide", () => {
     it("renders attendance slide when classAttendance provided", async () => {
-      const data = createClassData(
-        [{ num: 1, average: 4.0 }],
-        undefined,
-        { percentage: 92.5, date: "10.01.2026" }
-      );
+      const data = createClassData([{ num: 1, average: 4.0 }], undefined, {
+        percentage: 92.5,
+        date: "10.01.2026",
+      });
 
       const html = await generatePresentation(data);
 
@@ -370,11 +373,9 @@ describe("generatePresentation", () => {
     });
 
     it("renders attendance without date when date not provided", async () => {
-      const data = createClassData(
-        [{ num: 1, average: 4.0 }],
-        undefined,
-        { percentage: 88.0 }
-      );
+      const data = createClassData([{ num: 1, average: 4.0 }], undefined, {
+        percentage: 88.0,
+      });
 
       const html = await generatePresentation(data);
 
@@ -383,16 +384,53 @@ describe("generatePresentation", () => {
     });
 
     it("uses Polish decimal separator (comma) for percentage", async () => {
-      const data = createClassData(
-        [{ num: 1, average: 4.0 }],
-        undefined,
-        { percentage: 93.75 }
-      );
+      const data = createClassData([{ num: 1, average: 4.0 }], undefined, {
+        percentage: 93.75,
+      });
 
       const html = await generatePresentation(data);
 
       expect(html).toContain("93,8%");
       expect(html).not.toContain("93.8%");
     });
+  });
+
+  it("renders aggregate grades slide", async () => {
+    const data = createClassData([
+      { num: 1, grades: [{ subject: "Matematyka", value: "5" }] },
+      { num: 2, grades: [{ subject: "Matematyka", value: "4" }] },
+    ]);
+
+    // Mock aggregate grade distribution to trigger slide rendering
+    // Since createClassData doesn't support passing it directly
+    data.aggregateGradeDistribution = {
+      excellent: 1,
+      veryGood: 1,
+      good: 0,
+      satisfactory: 0,
+      acceptable: 0,
+      failing: 0,
+      unclassified: 0,
+    };
+
+    const html = await generatePresentation(data);
+
+    expect(html).toContain("Rozkład wszystkich ocen");
+    expect(html).toContain("Bardzo dobry (5)");
+  });
+
+  it("calculates and renders subject enrollment statistics", async () => {
+    const data = createClassData([
+      { num: 1, grades: [{ subject: "Etyka", value: "zwolniony" }] }, // Not enrolled
+      { num: 2, grades: [{ subject: "Etyka", value: "5" }] }, // Enrolled
+      { num: 3, grades: [{ subject: "Etyka", value: "4" }] }, // Enrolled
+    ]);
+
+    const html = await generatePresentation(data);
+
+    expect(html).toContain("Przedmioty dodatkowe");
+    expect(html).toContain("Etyka");
+    // Should be 2 students enrolled out of 3
+    expect(html).toContain("<td>2</td>");
   });
 });

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -6,6 +6,8 @@ import {
   countGradesBySubject,
   countBehaviorGrades,
   getTopStudents,
+  getOptionalSubjects,
+  countStudentsBySubject,
 } from "../analytics/index.js";
 import {
   createSubjectAveragesChart,
@@ -50,6 +52,8 @@ export async function generatePresentation(data: ClassData): Promise<string> {
   const subjectAverages = calculateSubjectAverages(students);
   const gradesBySubject = countGradesBySubject(students);
   const behaviorCounts = countBehaviorGrades(students);
+  const subjectCounts = countStudentsBySubject(students);
+  const optionalSubjects = getOptionalSubjects(students);
 
   // Create chart configs
   const subjectChartConfig = createSubjectAveragesChart(subjectAverages);
@@ -100,6 +104,12 @@ export async function generatePresentation(data: ClassData): Promise<string> {
           .sort((a, b) => b.average - a.average || a.number - b.number)
       : null;
 
+  // Map optional subjects to the data structure
+  const subjectEnrollment = optionalSubjects.map((subject) => ({
+    subject,
+    count: subjectCounts.get(subject) ?? 0,
+  }));
+
   // Format date in Polish
   const generatedDate = new Date().toLocaleDateString("pl-PL", {
     year: "numeric",
@@ -133,6 +143,7 @@ export async function generatePresentation(data: ClassData): Promise<string> {
     failureStatistics: failureStatistics ?? null,
     aggregateGradeDistribution: aggregateGradeDistribution ?? null,
     aggregateGradesPieChart: aggregateGradesChartImage,
+    subjectEnrollment: subjectEnrollment.length > 0 ? subjectEnrollment : null,
   };
 
   return renderPresentation(presentationData);

--- a/packages/core/src/generator/template.test.ts
+++ b/packages/core/src/generator/template.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { escapeHtml, safeDataUrl, renderPresentation, type PresentationData } from "./template.js";
+import {
+  escapeHtml,
+  safeDataUrl,
+  renderPresentation,
+  type PresentationData,
+} from "./template.js";
 import { studentNumber } from "../types/index.js";
 
 function createTestPresentationData(
@@ -108,7 +113,7 @@ describe("renderPresentation - topStudents slide", () => {
     const data = createTestPresentationData({
       topStudents: [
         { number: studentNumber(5), average: 5.25 },
-        { number: studentNumber(12), average: 4.80 },
+        { number: studentNumber(12), average: 4.8 },
       ],
     });
 
@@ -121,9 +126,9 @@ describe("renderPresentation - topStudents slide", () => {
   it("shows student count in subtitle", () => {
     const data = createTestPresentationData({
       topStudents: [
-        { number: studentNumber(1), average: 5.00 },
-        { number: studentNumber(2), average: 4.90 },
-        { number: studentNumber(3), average: 4.80 },
+        { number: studentNumber(1), average: 5.0 },
+        { number: studentNumber(2), average: 4.9 },
+        { number: studentNumber(3), average: 4.8 },
       ],
     });
 
@@ -134,9 +139,7 @@ describe("renderPresentation - topStudents slide", () => {
 
   it("uses singular form for one student (Polish grammar)", () => {
     const data = createTestPresentationData({
-      topStudents: [
-        { number: studentNumber(1), average: 5.00 },
-      ],
+      topStudents: [{ number: studentNumber(1), average: 5.0 }],
     });
 
     const html = renderPresentation(data);
@@ -147,9 +150,7 @@ describe("renderPresentation - topStudents slide", () => {
 
   it("displays student numbers only (GDPR)", () => {
     const data = createTestPresentationData({
-      topStudents: [
-        { number: studentNumber(7), average: 5.00 },
-      ],
+      topStudents: [{ number: studentNumber(7), average: 5.0 }],
     });
 
     const html = renderPresentation(data);
@@ -161,14 +162,14 @@ describe("renderPresentation - topStudents slide", () => {
       html.indexOf("Najwyższe średnie"),
       html.indexOf("Zachowanie")
     );
-    expect(topStudentsSection).not.toMatch(/<th[^>]*>.*(?:Imię|Nazwisko|Uczeń).*<\/th>/i);
+    expect(topStudentsSection).not.toMatch(
+      /<th[^>]*>.*(?:Imię|Nazwisko|Uczeń).*<\/th>/i
+    );
   });
 
   it("formats averages with comma as decimal separator (Polish)", () => {
     const data = createTestPresentationData({
-      topStudents: [
-        { number: studentNumber(1), average: 5.25 },
-      ],
+      topStudents: [{ number: studentNumber(1), average: 5.25 }],
     });
 
     const html = renderPresentation(data);
@@ -198,9 +199,7 @@ describe("renderPresentation - topStudents slide", () => {
 
   it("renders slide between student averages and behavior", () => {
     const data = createTestPresentationData({
-      topStudents: [
-        { number: studentNumber(1), average: 5.00 },
-      ],
+      topStudents: [{ number: studentNumber(1), average: 5.0 }],
       behaviorCounts: {
         exemplary: 1,
         veryGood: 0,
@@ -500,5 +499,44 @@ describe("renderPresentation - aggregate grades slide", () => {
     expect(html).toContain("<td>10</td>");
     // No chart image
     expect(html).not.toContain("Wykres rozkładu ocen");
+  });
+
+  describe("subject enrollment slide", () => {
+    it("renders subject enrollment slide when data is present", () => {
+      const data = createTestPresentationData({
+        subjectEnrollment: [
+          { subject: "Edukacja zdrowotna", count: 15 },
+          { subject: "Etyka", count: 5 },
+        ],
+      });
+
+      const html = renderPresentation(data);
+
+      expect(html).toContain("<h2>Przedmioty dodatkowe</h2>");
+      expect(html).toContain("Edukacja zdrowotna");
+      expect(html).toContain("15");
+      expect(html).toContain("Etyka");
+      expect(html).toContain("5");
+    });
+
+    it("does not render subject enrollment slide when data is null", () => {
+      const data = createTestPresentationData({
+        subjectEnrollment: null,
+      });
+
+      const html = renderPresentation(data);
+
+      expect(html).not.toContain("<h2>Przedmioty dodatkowe</h2>");
+    });
+
+    it("does not render subject enrollment slide when data is empty", () => {
+      const data = createTestPresentationData({
+        subjectEnrollment: [],
+      });
+
+      const html = renderPresentation(data);
+
+      expect(html).not.toContain("<h2>Przedmioty dodatkowe</h2>");
+    });
   });
 });

--- a/packages/core/src/generator/template.ts
+++ b/packages/core/src/generator/template.ts
@@ -44,6 +44,7 @@ export interface PresentationData {
   failureStatistics: FailureStatistics | null;
   aggregateGradeDistribution: AggregateGradeDistribution | null;
   aggregateGradesPieChart: string | null;
+  subjectEnrollment: { subject: string; count: number }[] | null;
 }
 
 export interface GradeDistributionRow {
@@ -259,6 +260,37 @@ function renderOverviewSlide(data: PresentationData): string {
   </section>`;
 }
 
+function renderSubjectEnrollmentSlide(data: PresentationData): string {
+  if (!data.subjectEnrollment || data.subjectEnrollment.length === 0) {
+    return "";
+  }
+
+  const rows = data.subjectEnrollment
+    .map(
+      ({ subject, count }) => `
+        <tr>
+          <td>${escapeHtml(subject)}</td>
+          <td>${count}</td>
+        </tr>`
+    )
+    .join("");
+
+  return `
+  <section class="slide">
+    <h2>Przedmioty dodatkowe</h2>
+    <table>
+      <thead>
+        <tr>
+          <th scope="col">Przedmiot</th>
+          <th scope="col">Liczba uczniów</th>
+        </tr>
+      </thead>
+      <tbody>${rows}
+      </tbody>
+    </table>
+  </section>`;
+}
+
 function renderSubjectAveragesSlide(data: PresentationData): string {
   const chartUrl = safeDataUrl(data.charts.subjectAverages);
   const content = chartUrl
@@ -391,8 +423,12 @@ function renderAttendanceSlide(data: PresentationData): string {
 
   let failureStatsHtml = "";
   if (data.failureStatistics) {
-    const { noFailingGrades, oneToTwoFailingGrades, threeOrMoreFailingGrades, unclassified } =
-      data.failureStatistics;
+    const {
+      noFailingGrades,
+      oneToTwoFailingGrades,
+      threeOrMoreFailingGrades,
+      unclassified,
+    } = data.failureStatistics;
     failureStatsHtml = `
     <h3 class="section-heading">Zagrożenia</h3>
     <table>
@@ -608,7 +644,15 @@ export function renderPresentation(data: PresentationData): string {
   <title>Zebranie z rodzicami - ${escapeHtml(data.metadata.className)}</title>
   <style>${STYLES}</style>
 </head>
-<body>${renderTitleSlide(data)}${renderOverviewSlide(data)}${renderSubjectAveragesSlide(data)}${renderGradeDistributionSlide(data)}${renderStudentAveragesSlide(data)}${renderTopStudentsSlide(data)}${renderAttendanceSlide(data)}${renderAggregateGradesSlide(data)}${renderBehaviorSlide(data)}
+<body>${renderTitleSlide(data)}${renderOverviewSlide(
+    data
+  )}${renderSubjectEnrollmentSlide(data)}${renderSubjectAveragesSlide(
+    data
+  )}${renderGradeDistributionSlide(data)}${renderStudentAveragesSlide(
+    data
+  )}${renderTopStudentsSlide(data)}${renderAttendanceSlide(
+    data
+  )}${renderAggregateGradesSlide(data)}${renderBehaviorSlide(data)}
 </body>
 </html>`;
 }


### PR DESCRIPTION
Closes #58

## Changes
- Updated `PresentationData` interface to include `subjectEnrollment` statistics.
- Implemented `renderSubjectEnrollmentSlide` to render a table of optional subjects and enrolled student counts.
- Updated `generatePresentation` to calculate enrollment logic using `countStudentsBySubject` and `getOptionalSubjects`.
- Added unit tests for new slide rendering and data generation.

## Verification
- Validated against sample data `zestawienie-klasyfikacja.xlsx`.
- Ran full test suite with `pnpm test`.