### PR TITLE
fix: suppress font mtime warnings during tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,15 @@
+import { tmpdir } from 'node:os';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
     include: ['packages/*/src/**/*.test.ts'],
     setupFiles: ['./vitest.setup.ts'],
+    // Suppress fontconfig "Unable to revert mtime" warnings from node-canvas
+    // by directing font cache to a writable temp directory
+    env: {
+      FONTCONFIG_CACHE: tmpdir(),
+    },
     coverage: {
       provider: 'v8',
       include: ['packages/*/src/**/*.ts'],


### PR DESCRIPTION
## Summary
- Set `FONTCONFIG_CACHE` env var to OS temp directory in vitest config
- Prevents fontconfig from attempting to write to system font directories
- Eliminates "Unable to revert mtime" warnings on Linux CI

Closes #55

## Test plan
- [x] All 236 tests pass locally
- [ ] Verify no mtime warnings in CI output

🤖 Generated with [Claude Code](https://claude.com/claude-code)