### PR TITLE
feat(cli): add --date option for custom meeting date

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -137,4 +137,46 @@ describe('generate function', () => {
     expect(result.success).toBe(true);
     expect(result.outputPath).toBe('/path/to/klasa-5b.html');
   });
+
+  it('passes date option to generator when provided', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(parseVulcanXlsx).mockReturnValue({
+      metadata: {
+        className: '5b',
+        period: '2024/2025 - Semestr 1' as import('@klassroom/core').ClassPeriod,
+        teacher: 'Jan Kowalski',
+      },
+      students: [],
+    });
+    vi.mocked(generatePresentation).mockResolvedValue('<html>test</html>');
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+
+    await generate('/path/to/klasa-5b.xlsx', { date: '15 stycznia 2026' });
+
+    expect(generatePresentation).toHaveBeenCalledWith(
+      expect.anything(),
+      { meetingDate: '15 stycznia 2026' },
+    );
+  });
+
+  it('calls generator without options when date not provided', async () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(parseVulcanXlsx).mockReturnValue({
+      metadata: {
+        className: '5b',
+        period: '2024/2025 - Semestr 1' as import('@klassroom/core').ClassPeriod,
+        teacher: 'Jan Kowalski',
+      },
+      students: [],
+    });
+    vi.mocked(generatePresentation).mockResolvedValue('<html>test</html>');
+    vi.mocked(writeFile).mockResolvedValue(undefined);
+
+    await generate('/path/to/klasa-5b.xlsx');
+
+    expect(generatePresentation).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined,
+    );
+  });
 });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,7 +2,16 @@ import { existsSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { basename, dirname, extname, join } from 'node:path';
 import { Command } from 'commander';
-import { VERSION, parseVulcanXlsx, generatePresentation } from '@klassroom/core';
+import {
+  VERSION,
+  parseVulcanXlsx,
+  generatePresentation,
+  type GeneratePresentationOptions,
+} from '@klassroom/core';
+
+export interface GenerateOptions {
+  date?: string;
+}
 
 export interface GenerateResult {
   success: boolean;
@@ -10,7 +19,10 @@ export interface GenerateResult {
   error?: string;
 }
 
-export async function generate(xlsxPath: string): Promise<GenerateResult> {
+export async function generate(
+  xlsxPath: string,
+  options?: GenerateOptions,
+): Promise<GenerateResult> {
   // Check if file exists
   if (!existsSync(xlsxPath)) {
     return { success: false, error: `Plik nie istnieje: ${xlsxPath}` };
@@ -28,8 +40,11 @@ export async function generate(xlsxPath: string): Promise<GenerateResult> {
     // Parse XLSX
     const classData = parseVulcanXlsx(xlsxPath);
 
-    // Generate HTML
-    const html = await generatePresentation(classData);
+    // Generate HTML with optional meeting date
+    const generatorOptions: GeneratePresentationOptions | undefined = options?.date
+      ? { meetingDate: options.date }
+      : undefined;
+    const html = await generatePresentation(classData, generatorOptions);
 
     // Write output file
     const baseName = basename(xlsxPath, extname(xlsxPath));
@@ -55,8 +70,9 @@ export function createProgram(): Command {
     .command('generate')
     .description('Generuje prezentację HTML z pliku XLSX')
     .argument('<xlsx-path>', 'Ścieżka do pliku XLSX z eksportu Vulcan UONET+')
-    .action(async (xlsxPath: string) => {
-      const result = await generate(xlsxPath);
+    .option('-d, --date <date>', 'data zebrania na slajdzie tytułowym')
+    .action(async (xlsxPath: string, opts: GenerateOptions) => {
+      const result = await generate(xlsxPath, opts);
 
       if (result.success) {
         console.log(`Wygenerowano prezentację: ${result.outputPath}`);

--- a/packages/core/src/generator/index.test.ts
+++ b/packages/core/src/generator/index.test.ts
@@ -191,6 +191,38 @@ describe('generatePresentation', () => {
     });
   });
 
+  describe('meetingDate option', () => {
+    it('uses custom meeting date when provided', async () => {
+      const data = createClassData([]);
+
+      const html = await generatePresentation(data, { meetingDate: '15 stycznia 2026' });
+
+      expect(html).toContain('Data:</strong> 15 stycznia 2026');
+    });
+
+    it('uses current date when meetingDate not provided', async () => {
+      const data = createClassData([]);
+
+      const html = await generatePresentation(data);
+
+      // Should contain Polish-formatted current date (not a custom string)
+      expect(html).toMatch(
+        /Data:<\/strong>\s+\d{1,2}\s+(stycznia|lutego|marca|kwietnia|maja|czerwca|lipca|sierpnia|września|października|listopada|grudnia)\s+\d{4}/,
+      );
+    });
+
+    it('passes through meetingDate as-is without validation', async () => {
+      const data = createClassData([]);
+
+      // Various format examples that should all work (pass-through)
+      const html1 = await generatePresentation(data, { meetingDate: '15.01.2026' });
+      expect(html1).toContain('Data:</strong> 15.01.2026');
+
+      const html2 = await generatePresentation(data, { meetingDate: 'Styczeń 2026' });
+      expect(html2).toContain('Data:</strong> Styczeń 2026');
+    });
+  });
+
   describe('edge cases', () => {
     it('handles empty student list with zero values in overview', async () => {
       const data = createClassData([]);

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -23,6 +23,11 @@ import {
   type TopStudentRow,
 } from './template.js';
 
+export interface GeneratePresentationOptions {
+  /** Custom meeting date string for title slide. If omitted, uses current date. */
+  meetingDate?: string;
+}
+
 /**
  * Generates a self-contained HTML presentation for a parent-teacher meeting.
  *
@@ -30,14 +35,22 @@ import {
  * All text is in Polish.
  *
  * @param data - Parsed class data from Vulcan XLSX export
+ * @param options - Optional generation options
  * @returns Promise resolving to complete HTML string
  *
  * @example
  * const data = parseVulcanXlsx("grades.xlsx");
  * const html = await generatePresentation(data);
  * fs.writeFileSync("presentation.html", html);
+ *
+ * @example
+ * // With custom meeting date
+ * const html = await generatePresentation(data, { meetingDate: "15 stycznia 2026" });
  */
-export async function generatePresentation(data: ClassData): Promise<string> {
+export async function generatePresentation(
+  data: ClassData,
+  options?: GeneratePresentationOptions,
+): Promise<string> {
   const { metadata, students, classAttendance, failureStatistics, aggregateGradeDistribution } =
     data;
 
@@ -104,12 +117,14 @@ export async function generatePresentation(data: ClassData): Promise<string> {
     count: subjectCounts.get(subject) ?? 0,
   }));
 
-  // Format date in Polish
-  const generatedDate = new Date().toLocaleDateString('pl-PL', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
+  // Use custom meeting date if provided, otherwise format current date in Polish
+  const generatedDate =
+    options?.meetingDate ??
+    new Date().toLocaleDateString('pl-PL', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
 
   // Prepare presentation data
   const presentationData: PresentationData = {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,3 +72,4 @@ export type {
 
 // Generator
 export { generatePresentation } from './generator/index.js';
+export type { GeneratePresentationOptions } from './generator/index.js';


### PR DESCRIPTION
## Summary

- Add `--date` / `-d` CLI option to specify custom meeting date on title slide
- Date string is passed through without validation, supporting any format (e.g., "15 stycznia 2026", "15.01.2026", "Styczeń 2026")
- Without the option, current date is used (existing behavior preserved)

## Test plan

- [x] Run `pnpm test` - all 241 tests pass (5 new tests added)
- [x] Run `pnpm build` - TypeScript compiles without errors
- [ ] Manual test: `klassroom generate grades.xlsx --date "15 stycznia 2026"` shows custom date
- [ ] Manual test: `klassroom generate grades.xlsx` shows current date

🤖 Generated with [Claude Code](https://claude.com/claude-code)