### PR TITLE
feat(core): read VERSION from package.json at runtime

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,15 +1,19 @@
 import { describe, it, expect } from 'vitest';
 import { exec as execCallback } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { promisify } from 'node:util';
 import { VERSION } from './index.js';
 
 const exec = promisify(execCallback);
 const CLI_PATH = resolve(__dirname, '../dist/index.js');
+const corePackageJson = JSON.parse(
+  readFileSync(resolve(__dirname, '../../core/package.json'), 'utf-8'),
+);
 
 describe('@klassroom/cli', () => {
-  it('re-exports VERSION from core', () => {
-    expect(VERSION).toBe('0.0.0');
+  it('re-exports VERSION from core package.json', () => {
+    expect(VERSION).toBe(corePackageJson.version);
   });
 
   describe('CLI Execution', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
-export const VERSION = '0.0.0';
+import packageJson from '../package.json' with { type: 'json' };
+export const VERSION: string = packageJson.version;
 
 // Types (public API - all GDPR-safe)
 export type {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
+    "resolveJsonModule": true,
     "strict": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "module": "Node16",
-    "moduleResolution": "Node16",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "target": "ES2022",
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Replace hardcoded `VERSION = '0.0.0'` with dynamic import from `package.json`
- Enable `resolveJsonModule` and upgrade module system to `NodeNext` for import attributes support
- Update VERSION test to verify against `package.json` instead of hardcoded value

Closes #16

## Test plan

- [x] All 241 existing tests pass
- [x] `klassroom --version` displays correct version from package.json
- [x] Build succeeds with `pnpm build`

🤖 Generated with [Claude Code](https://claude.ai/code)