### PR TITLE
docs(readme): document AI conclusions and CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Generate HTML semester presentations from Polish school grade exports.
 - 🇵🇱 **Polish Language**: All output (charts, labels, UI) is in Polish.
 - 🔒 **GDPR Compliant**: Processes data locally, outputting only student numbers (no names).
 - 🏫 **Vulcan UONET+ Support**: Native support for the "Internal Documentation" XLSX export.
+- 🤖 **AI Conclusions** (optional): Generate intelligent summaries with Google Gemini free tier.
 
 ## Supported Formats
 
@@ -56,25 +57,52 @@ klassroom generate path/to/grades.xlsx
 
 ### CLI Reference
 
-**`klassroom generate <xlsx-path>`**
+**`klassroom generate <xlsx-path> [options]`**
 
 Generates an HTML presentation from the provided Vulcan XLSX file.
 
+**Arguments:**
+
 - `<xlsx-path>`: Path to the Vulcan UONET+ XLSX export file.
+
+**Options:**
+
+- `-d, --date <date>`: Custom meeting date for the title slide.
+- `--ai`: Generate AI-powered conclusions (requires `GEMINI_API_KEY`).
 
 _Example:_
 
 ```bash
-node packages/cli/dist/cli.js generate ./exports/semestr1.xlsx
+klassroom generate ./exports/semestr1.xlsx
 # -> ./exports/semestr1.html
+
+# With custom date and AI conclusions
+klassroom generate --ai --date "15 stycznia 2025" ./exports/semestr1.xlsx
 ```
+
+### AI Conclusions (Optional)
+
+Generate intelligent class summaries using Google Gemini (free tier, no credit card required):
+
+1. Get an API key from [Google AI Studio](https://aistudio.google.com/)
+2. Set the environment variable:
+   ```bash
+   export GEMINI_API_KEY=your_key
+   ```
+3. Run with the `--ai` flag:
+   ```bash
+   klassroom generate --ai grades.xlsx
+   ```
+
+The AI analyzes aggregate class statistics and generates Polish-language conclusions with strengths, areas for improvement, and recommendations.
 
 ## Privacy & GDPR
 
 This tool is designed with student privacy as a priority:
 
-- **Local Processing**: All parsing and generation happens on your machine. Data is never sent to the cloud.
+- **Local Processing**: All parsing and generation happens on your machine. No data is sent externally by default.
 - **Anonymized Output**: The generated HTML file refers to students only by their journal number ("Nr w dzienniku"). Student names are used internally for parsing but are **never** included in the output.
+- **AI Mode (`--ai`)**: When enabled, only aggregate class statistics (averages, distributions, counts) are sent to Google Gemini. Individual student data (names, numbers, grades) is never transmitted.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add AI Conclusions feature to Features list
- Document `-d, --date` and `--ai` CLI options in CLI Reference
- Add "AI Conclusions (Optional)" setup instructions subsection
- Update Privacy & GDPR section to clarify AI data handling

## Why
The README was outdated after PR #68 (AI conclusions) and PR #65 (custom date option) were merged. The Privacy section incorrectly stated "Data is never sent to the cloud" which is inaccurate when `--ai` is enabled.

## Changes
| Section | Change |
|---------|--------|
| Features | Added 🤖 AI Conclusions bullet |
| CLI Reference | Added Arguments/Options documentation |
| New subsection | AI setup instructions with Google AI Studio link |
| Privacy & GDPR | Clarified AI mode sends only aggregate stats |

🤖 Generated with [Claude Code](https://claude.ai/code)