### PR TITLE
chore: bump version to 0.1.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klassroom/cli",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klassroom/core",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bump `@klassroom/core` version to 0.1.0
- Bump `@klassroom/cli` version to 0.1.0

## Why
MVP release preparation. This version bump enables creating the v0.1.0 GitHub release.

## Related
- Milestone: [v0.1.0](https://github.com/bitcraft-apps/klassroom/milestone/2) (MVP Release)

🤖 Generated with [Claude Code](https://claude.ai/code)