### PR TITLE
feat(web): add data preview component

### DIFF
--- a/packages/web/src/components/preview.css
+++ b/packages/web/src/components/preview.css
@@ -1,0 +1,115 @@
+.preview {
+  max-width: 32rem;
+}
+
+/* Metadata section */
+.preview__meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.25rem 1rem;
+  margin: 0 0 1.5rem 0;
+}
+
+.preview__label {
+  font-weight: 600;
+  color: #374151;
+}
+
+.preview__value {
+  margin: 0;
+  color: #4b5563;
+}
+
+/* Sections */
+.preview__section {
+  margin-bottom: 1.5rem;
+}
+
+.preview__section-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #374151;
+}
+
+.preview__subjects {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #4b5563;
+}
+
+.preview__subjects li {
+  margin-bottom: 0.125rem;
+}
+
+/* Warnings section */
+.preview__section--warnings {
+  padding: 0.75rem 1rem;
+  background-color: #fef3c7;
+  border-radius: 6px;
+}
+
+.preview__section--warnings .preview__section-title {
+  color: #92400e;
+}
+
+.preview__warnings {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #92400e;
+}
+
+.preview__warnings li {
+  margin-bottom: 0.125rem;
+}
+
+/* Actions */
+.preview__actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.preview__button {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s;
+}
+
+.preview__button:focus {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+
+.preview__button--primary {
+  background-color: #3b82f6;
+  color: white;
+  border: 1px solid #3b82f6;
+}
+
+.preview__button--primary:hover:not(:disabled) {
+  background-color: #2563eb;
+  border-color: #2563eb;
+}
+
+.preview__button--primary:disabled {
+  background-color: #9ca3af;
+  border-color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.preview__button--secondary {
+  background-color: white;
+  color: #374151;
+  border: 1px solid #d1d5db;
+}
+
+.preview__button--secondary:hover {
+  background-color: #f9fafb;
+  border-color: #9ca3af;
+}

--- a/packages/web/src/components/preview.test.ts
+++ b/packages/web/src/components/preview.test.ts
@@ -1,0 +1,305 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createPreview,
+  type PreviewData,
+  type PreviewEvents,
+} from './preview.js';
+
+describe('createPreview', () => {
+  let container: HTMLElement;
+  let events: PreviewEvents;
+  let data: PreviewData;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    events = {
+      onGenerate: vi.fn(),
+      onCancel: vi.fn(),
+    };
+    data = {
+      className: '3A',
+      period: '2024/2025 - Semestr 1',
+      teacher: 'Anna Kowalska',
+      studentCount: 25,
+      subjects: ['Matematyka', 'Język polski', 'Fizyka'],
+      warnings: [],
+    };
+  });
+
+  describe('DOM structure', () => {
+    it('creates preview root in container', () => {
+      createPreview(container, data, events);
+
+      const preview = container.querySelector('.preview');
+      expect(preview).toBeTruthy();
+    });
+
+    it('clears container before rendering', () => {
+      container.innerHTML = '<div>existing content</div>';
+
+      createPreview(container, data, events);
+
+      expect(container.querySelector('.preview')).toBeTruthy();
+      expect(container.textContent).not.toContain('existing content');
+    });
+
+    it('creates metadata section', () => {
+      createPreview(container, data, events);
+
+      const meta = container.querySelector('.preview__meta');
+      expect(meta).toBeTruthy();
+    });
+
+    it('creates subjects section', () => {
+      createPreview(container, data, events);
+
+      const subjects = container.querySelector('.preview__subjects');
+      expect(subjects).toBeTruthy();
+    });
+
+    it('creates action buttons', () => {
+      createPreview(container, data, events);
+
+      const primaryBtn = container.querySelector('.preview__button--primary');
+      const secondaryBtn = container.querySelector('.preview__button--secondary');
+
+      expect(primaryBtn).toBeTruthy();
+      expect(secondaryBtn).toBeTruthy();
+    });
+  });
+
+  describe('Polish labels', () => {
+    it('displays class label in Polish', () => {
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Klasa:');
+    });
+
+    it('displays period label in Polish', () => {
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Okres:');
+    });
+
+    it('displays teacher label in Polish', () => {
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Wychowawca:');
+    });
+
+    it('displays student count label in Polish', () => {
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Liczba uczniów:');
+    });
+
+    it('displays subjects label in Polish', () => {
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Przedmioty:');
+    });
+
+    it('displays generate button text in Polish', () => {
+      createPreview(container, data, events);
+
+      const btn = container.querySelector('.preview__button--primary');
+      expect(btn?.textContent).toBe('Generuj prezentację');
+    });
+
+    it('displays cancel button text in Polish', () => {
+      createPreview(container, data, events);
+
+      const btn = container.querySelector('.preview__button--secondary');
+      expect(btn?.textContent).toBe('Wybierz inny plik');
+    });
+  });
+
+  describe('data display', () => {
+    it('displays className', () => {
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('3A');
+    });
+
+    it('displays period', () => {
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('2024/2025 - Semestr 1');
+    });
+
+    it('displays teacher', () => {
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Anna Kowalska');
+    });
+
+    it('displays studentCount', () => {
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('25');
+    });
+
+    it('displays all subjects', () => {
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Matematyka');
+      expect(container.textContent).toContain('Język polski');
+      expect(container.textContent).toContain('Fizyka');
+    });
+  });
+
+  describe('empty data handling', () => {
+    it('shows "Brak danych" for empty className', () => {
+      data.className = '';
+
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Brak danych');
+    });
+
+    it('shows "Brak danych" for empty period', () => {
+      data.period = '';
+
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Brak danych');
+    });
+
+    it('shows "Brak danych" for empty teacher', () => {
+      data.teacher = '';
+
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Brak danych');
+    });
+
+    it('shows "Brak danych" for empty subjects', () => {
+      data.subjects = [];
+
+      createPreview(container, data, events);
+
+      const subjectsList = container.querySelector('.preview__subjects');
+      expect(subjectsList?.textContent).toContain('Brak danych');
+    });
+  });
+
+  describe('warnings section', () => {
+    it('hides warnings section when warnings array is empty', () => {
+      data.warnings = [];
+
+      createPreview(container, data, events);
+
+      const warningsSection = container.querySelector(
+        '.preview__section--warnings',
+      );
+      expect(warningsSection).toBeNull();
+    });
+
+    it('shows warnings section when warnings exist', () => {
+      data.warnings = ['Brak ocen z matematyki'];
+
+      createPreview(container, data, events);
+
+      const warningsSection = container.querySelector(
+        '.preview__section--warnings',
+      );
+      expect(warningsSection).toBeTruthy();
+    });
+
+    it('displays all warnings', () => {
+      data.warnings = ['Brak ocen z matematyki', 'Brak średniej dla ucznia 5'];
+
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Brak ocen z matematyki');
+      expect(container.textContent).toContain('Brak średniej dla ucznia 5');
+    });
+
+    it('displays warnings label in Polish', () => {
+      data.warnings = ['Test warning'];
+
+      createPreview(container, data, events);
+
+      expect(container.textContent).toContain('Uwagi:');
+    });
+  });
+
+  describe('button interactions', () => {
+    it('calls onGenerate when generate button clicked', () => {
+      createPreview(container, data, events);
+
+      const btn = container.querySelector(
+        '.preview__button--primary',
+      ) as HTMLButtonElement;
+      btn.click();
+
+      expect(events.onGenerate).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onCancel when cancel button clicked', () => {
+      createPreview(container, data, events);
+
+      const btn = container.querySelector(
+        '.preview__button--secondary',
+      ) as HTMLButtonElement;
+      btn.click();
+
+      expect(events.onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('zero students handling', () => {
+    it('disables generate button when studentCount is 0', () => {
+      data.studentCount = 0;
+
+      createPreview(container, data, events);
+
+      const btn = container.querySelector(
+        '.preview__button--primary',
+      ) as HTMLButtonElement;
+      expect(btn.disabled).toBe(true);
+    });
+
+    it('enables generate button when studentCount > 0', () => {
+      data.studentCount = 5;
+
+      createPreview(container, data, events);
+
+      const btn = container.querySelector(
+        '.preview__button--primary',
+      ) as HTMLButtonElement;
+      expect(btn.disabled).toBe(false);
+    });
+
+    it('does not call onGenerate when disabled button clicked', () => {
+      data.studentCount = 0;
+
+      createPreview(container, data, events);
+
+      const btn = container.querySelector(
+        '.preview__button--primary',
+      ) as HTMLButtonElement;
+      btn.click();
+
+      expect(events.onGenerate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GDPR compliance', () => {
+    it('does not render any student names', () => {
+      // PreviewData interface intentionally excludes student names
+      // This test verifies the interface design by checking the data shape
+      expect(data).not.toHaveProperty('students');
+      expect(data).not.toHaveProperty('studentNames');
+
+      createPreview(container, data, events);
+
+      // Verify only count is shown, not names
+      expect(container.textContent).toContain('25');
+      expect(container.textContent).not.toContain('Jan Kowalski');
+    });
+  });
+});

--- a/packages/web/src/components/preview.ts
+++ b/packages/web/src/components/preview.ts
@@ -1,0 +1,169 @@
+/**
+ * Data preview component for verifying parsed XLSX data before generation.
+ * Polish UI text. Displays class metadata, subjects, and warnings.
+ */
+
+import './preview.css';
+
+// Polish UI text
+const LABEL_CLASS = 'Klasa:';
+const LABEL_PERIOD = 'Okres:';
+const LABEL_TEACHER = 'Wychowawca:';
+const LABEL_STUDENT_COUNT = 'Liczba uczniów:';
+const LABEL_SUBJECTS = 'Przedmioty:';
+const LABEL_WARNINGS = 'Uwagi:';
+const TEXT_NO_DATA = 'Brak danych';
+const BUTTON_GENERATE = 'Generuj prezentację';
+const BUTTON_CANCEL = 'Wybierz inny plik';
+
+/**
+ * Data shape for the preview component.
+ * Caller transforms parser output to this shape (GDPR boundary).
+ */
+export interface PreviewData {
+  className: string;
+  period: string;
+  teacher: string;
+  studentCount: number;
+  subjects: string[];
+  warnings: string[];
+}
+
+/**
+ * Callback events for the preview component.
+ */
+export interface PreviewEvents {
+  onGenerate: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Creates a data preview showing parsed class info before presentation generation.
+ * Polish UI text. Shows metadata, subjects, warnings, and action buttons.
+ *
+ * @param container - Parent element to mount the component into
+ * @param data - Parsed class data to display
+ * @param events - Callback handlers for generate and cancel actions
+ */
+export function createPreview(
+  container: HTMLElement,
+  data: PreviewData,
+  events: PreviewEvents,
+): void {
+  // Clear container
+  container.innerHTML = '';
+
+  // Create DOM structure
+  const root = document.createElement('div');
+  root.className = 'preview';
+
+  // Metadata section
+  const metaSection = document.createElement('dl');
+  metaSection.className = 'preview__meta';
+
+  const metaItems: [string, string][] = [
+    [LABEL_CLASS, data.className || TEXT_NO_DATA],
+    [LABEL_PERIOD, data.period || TEXT_NO_DATA],
+    [LABEL_TEACHER, data.teacher || TEXT_NO_DATA],
+    [LABEL_STUDENT_COUNT, String(data.studentCount)],
+  ];
+
+  for (const [label, value] of metaItems) {
+    const dt = document.createElement('dt');
+    dt.className = 'preview__label';
+    dt.textContent = label;
+
+    const dd = document.createElement('dd');
+    dd.className = 'preview__value';
+    dd.textContent = value;
+
+    metaSection.appendChild(dt);
+    metaSection.appendChild(dd);
+  }
+
+  root.appendChild(metaSection);
+
+  // Subjects section
+  const subjectsSection = document.createElement('div');
+  subjectsSection.className = 'preview__section';
+
+  const subjectsLabel = document.createElement('h3');
+  subjectsLabel.className = 'preview__section-title';
+  subjectsLabel.textContent = LABEL_SUBJECTS;
+
+  const subjectsList = document.createElement('ul');
+  subjectsList.className = 'preview__subjects';
+
+  if (data.subjects.length > 0) {
+    for (const subject of data.subjects) {
+      const li = document.createElement('li');
+      li.textContent = subject;
+      subjectsList.appendChild(li);
+    }
+  } else {
+    const li = document.createElement('li');
+    li.textContent = TEXT_NO_DATA;
+    subjectsList.appendChild(li);
+  }
+
+  subjectsSection.appendChild(subjectsLabel);
+  subjectsSection.appendChild(subjectsList);
+  root.appendChild(subjectsSection);
+
+  // Warnings section (hidden when empty)
+  if (data.warnings.length > 0) {
+    const warningsSection = document.createElement('div');
+    warningsSection.className = 'preview__section preview__section--warnings';
+
+    const warningsLabel = document.createElement('h3');
+    warningsLabel.className = 'preview__section-title';
+    warningsLabel.textContent = LABEL_WARNINGS;
+
+    const warningsList = document.createElement('ul');
+    warningsList.className = 'preview__warnings';
+
+    for (const warning of data.warnings) {
+      const li = document.createElement('li');
+      li.textContent = warning;
+      warningsList.appendChild(li);
+    }
+
+    warningsSection.appendChild(warningsLabel);
+    warningsSection.appendChild(warningsList);
+    root.appendChild(warningsSection);
+  }
+
+  // Actions section
+  const actionsSection = document.createElement('div');
+  actionsSection.className = 'preview__actions';
+
+  const generateButton = document.createElement('button');
+  generateButton.className = 'preview__button preview__button--primary';
+  generateButton.type = 'button';
+  generateButton.textContent = BUTTON_GENERATE;
+
+  // Disable generate when no students
+  if (data.studentCount === 0) {
+    generateButton.disabled = true;
+  }
+
+  const cancelButton = document.createElement('button');
+  cancelButton.className = 'preview__button preview__button--secondary';
+  cancelButton.type = 'button';
+  cancelButton.textContent = BUTTON_CANCEL;
+
+  // Event handlers
+  generateButton.addEventListener('click', () => {
+    events.onGenerate();
+  });
+
+  cancelButton.addEventListener('click', () => {
+    events.onCancel();
+  });
+
+  actionsSection.appendChild(generateButton);
+  actionsSection.appendChild(cancelButton);
+  root.appendChild(actionsSection);
+
+  container.appendChild(root);
+}


### PR DESCRIPTION
## Summary
- Add `createPreview` function in `@klassroom/web` that displays parsed class data before presentation generation
- Users can verify XLSX was read correctly, then proceed with "Generuj prezentację" or cancel with "Wybierz inny plik"
- All UI text in Polish, follows existing `createFileUpload` patterns

## Test plan
- [x] 31 unit tests pass covering DOM structure, Polish labels, data display, empty data handling, warnings section, button interactions, zero students handling, and GDPR compliance
- [x] TypeScript typecheck passes
- [ ] Manual test: integrate with file upload flow to verify end-to-end behavior

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)