### PR TITLE
fix(core): use dynamic import for AI module to fix browser error (#92)

### DIFF
--- a/packages/core/src/generator/core.ts
+++ b/packages/core/src/generator/core.ts
@@ -21,7 +21,7 @@ import {
   type GradeDistributionRow,
   type TopStudentRow,
 } from './template.js';
-import { generateConclusions, type AnalyticsResult } from '../ai/index.js';
+import type { AnalyticsResult } from '../ai/index.js';
 
 /**
  * Context for chart rendering - allows dependency injection of
@@ -126,6 +126,7 @@ export async function generatePresentationCore(
   const topStudentsData = getTopStudents(students);
 
   // Generate AI conclusions if enabled (uses only aggregate data - GDPR safe)
+  // Uses dynamic import to avoid bundling Node-only AI code in browser builds
   let aiConclusionsText: string | null = null;
   if (options?.aiConclusions) {
     const analyticsResult: AnalyticsResult = {
@@ -141,6 +142,7 @@ export async function generatePresentationCore(
       behaviorDistribution: hasBehaviorData ? behaviorCounts : undefined,
       failureStatistics,
     };
+    const { generateConclusions } = await import('../ai/index.js');
     aiConclusionsText = await generateConclusions(
       analyticsResult,
       options.geminiApiKey,


### PR DESCRIPTION
## Summary

- Convert static import of `generateConclusions` to dynamic import inside the conditional block
- Prevents Node.js-only code (`process.env`) from being bundled in browser builds
- Fixes `ReferenceError: process is not defined` when loading web app

Closes #92

## Test plan

- [x] `grep -r "process\.env" packages/web/dist/` returns no matches after build
- [x] All 337 tests pass
- [x] CLI builds and runs successfully
- [x] Web app builds successfully (37 modules, 210KB bundle)

🤖 Generated with [Claude Code](https://claude.ai/code)