### PR TITLE
feat(web): configure for Cloudflare Pages deployment (#81)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "tsc --build tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json && pnpm -F @klassroom/web build",
     "clean": "tsc --build --clean tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -7,6 +7,7 @@
     <meta name="theme-color" content="#2563eb" />
     <meta property="og:title" content="Klassroom - Generator prezentacji z ocenami" />
     <meta property="og:description" content="Generator prezentacji z ocenami dla zebrań z rodzicami. Przetwarzanie lokalne w przeglądarce." />
+    <meta property="og:image" content="https://klassroom.pages.dev/apple-touch-icon.png" />
     <meta property="og:type" content="website" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="icon" href="/icon.svg" type="image/svg+xml" />

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  base: '/klassroom/',
+  base: '/',
 });


### PR DESCRIPTION
## Summary
- Change Vite base path from `/klassroom/` to `/` for root deployment on pages.dev
- Add og:image meta tag for social sharing preview
- Include web build in root build script so `pnpm build` produces deployable assets

## Cloudflare Dashboard Settings Required
After merge, configure in Cloudflare Pages:
- **Build command**: `pnpm build`
- **Build output**: `packages/web/dist`
- **Deploy command**: (leave empty - not needed for static hosting)

## Test plan
- [ ] CI passes
- [ ] After merge, deployment succeeds at https://klassroom.pages.dev/

🤖 Generated with [Claude Code](https://claude.com/claude-code)