### PR TITLE
fix: resolve ESLint errors and enable CI linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,5 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build
-      # - run: pnpm lint  # Enable after linting is set up
+      - run: pnpm lint
       - run: pnpm test

--- a/packages/core/src/generator/browser.ts
+++ b/packages/core/src/generator/browser.ts
@@ -8,8 +8,7 @@ import {
   type GeneratePresentationCoreOptions,
 } from './core.js';
 
-export interface BrowserGeneratePresentationOptions
-  extends GeneratePresentationCoreOptions {}
+export type BrowserGeneratePresentationOptions = GeneratePresentationCoreOptions;
 
 /**
  * Generates a self-contained HTML presentation for a parent-teacher meeting.

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -5,8 +5,7 @@ import {
   type GeneratePresentationCoreOptions,
 } from './core.js';
 
-export interface GeneratePresentationOptions
-  extends GeneratePresentationCoreOptions {}
+export type GeneratePresentationOptions = GeneratePresentationCoreOptions;
 
 /**
  * Generates a self-contained HTML presentation for a parent-teacher meeting.

--- a/packages/web/src/components/generator.test.ts
+++ b/packages/web/src/components/generator.test.ts
@@ -7,7 +7,7 @@ import {
   type GeneratorData,
   type GeneratorEvents,
 } from './generator.js';
-import type { ClassData, ClassPeriod, StudentNumber } from '@klassroom/core';
+import type { ClassPeriod, StudentNumber } from '@klassroom/core';
 
 // Mock @klassroom/core/browser
 vi.mock('@klassroom/core/browser', () => ({

--- a/packages/web/src/utils/download.test.ts
+++ b/packages/web/src/utils/download.test.ts
@@ -186,6 +186,7 @@ describe('downloadFile', () => {
   it('sets correct href and download attributes on anchor', () => {
     let capturedAnchor: HTMLAnchorElement | null = null;
     clickSpy.mockImplementation(function (this: HTMLAnchorElement) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias -- Intentional capture for test assertion
       capturedAnchor = this;
     });
 


### PR DESCRIPTION
## Summary

- Convert empty interfaces to type aliases in generator modules
- Remove unused `ClassData` import from test file
- Add eslint-disable for intentional `this` capture in test mock
- Enable `pnpm lint` step in CI workflow

Closes #111

## Test plan

- [x] `pnpm lint` passes with 0 errors and 0 warnings
- [x] All 411 tests pass
- [ ] CI pipeline passes with linting enabled

🤖 Generated with [Claude Code](https://claude.ai/code)