### PR TITLE
docs: add security policy for vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,9 @@ These are non-binding targets for a small team:
 
 - **Acknowledgment**: Within 7 days
 - **Assessment**: Within 14 days
-- **Public disclosure**: Coordinated with reporter, typically after fix is released (90-day maximum)
+- **Public disclosure**: Coordinated with reporter after fix is released, or after 90 days (whichever comes first)
+
+Security fixes are announced via GitHub Security Advisories and release notes.
 
 ## Scope
 
@@ -45,9 +47,11 @@ The following are in scope for security reports:
 
 ### Out of Scope
 
-- Denial of service attacks
+- Volumetric denial of service (rate limiting, bandwidth exhaustion)
 - Social engineering attacks
 - Issues in unsupported versions
+
+Input validation vulnerabilities (including malformed XLSX handling) are in scope, even if they cause resource exhaustion.
 
 For third-party dependency vulnerabilities, please report upstream. If the issue directly impacts Klassroom users, notify us as well.
 


### PR DESCRIPTION
## Summary
- Add SECURITY.md with supported versions, vulnerability reporting instructions, and GDPR considerations
- Uses GitHub private vulnerability reporting (no email infrastructure needed)
- Defines response timeline and scope for all packages

## Test plan
- [ ] Verify SECURITY.md appears at repository root
- [ ] Check GitHub displays "Security policy" link in repo sidebar
- [ ] Confirm file renders correctly on GitHub

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)