### PR TITLE
fix(ci): use simple version tags without component prefix

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     ".": {
       "release-type": "node",
       "bump-minor-pre-major": true,
+      "include-component-in-tag": false,
       "extra-files": [
         "packages/core/package.json",
         "packages/cli/package.json",


### PR DESCRIPTION
## Summary

Configures release-please to create tags like `v0.3.0` instead of `klassroom-v0.3.0`.

This aligns with existing tags (`v0.1.0`, `v0.2.0`) and eliminates the workflow warning:
```
⚠ Found release tag with component '', but not configured in manifest
❯ looking for tagName: klassroom-v0.2.0
```

## Changes

- Added `"include-component-in-tag": false` to `release-please-config.json`

## Related

- Fixes warning from #122
- Closes #123

🤖 Generated with [Claude Code](https://claude.ai/code)