### PR TITLE
chore: format codebase with prettier

### DIFF
--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -156,10 +156,9 @@ describe('generate function', () => {
 
     await generate('/path/to/klasa-5b.xlsx', { date: '15 stycznia 2026' });
 
-    expect(generatePresentation).toHaveBeenCalledWith(
-      expect.anything(),
-      { meetingDate: '15 stycznia 2026' },
-    );
+    expect(generatePresentation).toHaveBeenCalledWith(expect.anything(), {
+      meetingDate: '15 stycznia 2026',
+    });
   });
 
   it('calls generator without options when date not provided', async () => {
@@ -177,9 +176,9 @@ describe('generate function', () => {
 
     await generate('/path/to/klasa-5b.xlsx');
 
-    expect(generatePresentation).toHaveBeenCalledWith(
-      expect.anything(),
-      { meetingDate: undefined, aiConclusions: undefined },
-    );
+    expect(generatePresentation).toHaveBeenCalledWith(expect.anything(), {
+      meetingDate: undefined,
+      aiConclusions: undefined,
+    });
   });
 });

--- a/packages/core/src/browser.ts
+++ b/packages/core/src/browser.ts
@@ -13,10 +13,7 @@ export { generatePresentationBrowser } from './generator/browser.js';
 export type { BrowserGeneratePresentationOptions } from './generator/browser.js';
 
 // Browser-compatible chart renderer
-export {
-  renderChartToDataUrl,
-  PLACEHOLDER_IMAGE,
-} from './generator/render-charts-browser.js';
+export { renderChartToDataUrl, PLACEHOLDER_IMAGE } from './generator/render-charts-browser.js';
 
 // Chart configuration types (no Node.js dependencies)
 export type {

--- a/packages/core/src/generator/browser.test.ts
+++ b/packages/core/src/generator/browser.test.ts
@@ -11,13 +11,7 @@ function createClassData(
     num: number;
     grades?: Array<{ subject: string; value: string | null }>;
     average?: number;
-    behavior?:
-      | 'exemplary'
-      | 'veryGood'
-      | 'good'
-      | 'acceptable'
-      | 'inappropriate'
-      | 'reprehensible';
+    behavior?: 'exemplary' | 'veryGood' | 'good' | 'acceptable' | 'inappropriate' | 'reprehensible';
   }>,
   metadata?: Partial<ClassData['metadata']>,
 ): ClassData {
@@ -80,9 +74,9 @@ describe('generatePresentationBrowser', () => {
     it('throws error when aiConclusions enabled without geminiApiKey', async () => {
       const data = createClassData([]);
 
-      await expect(
-        generatePresentationBrowser(data, { aiConclusions: true }),
-      ).rejects.toThrow('geminiApiKey is required when aiConclusions is enabled');
+      await expect(generatePresentationBrowser(data, { aiConclusions: true })).rejects.toThrow(
+        'geminiApiKey is required when aiConclusions is enabled',
+      );
     });
 
     it('passes validation when aiConclusions enabled with geminiApiKey', async () => {

--- a/packages/core/src/generator/browser.ts
+++ b/packages/core/src/generator/browser.ts
@@ -1,12 +1,6 @@
 import type { ClassData } from '../types/index.js';
-import {
-  renderChartToDataUrl,
-  PLACEHOLDER_IMAGE,
-} from './render-charts-browser.js';
-import {
-  generatePresentationCore,
-  type GeneratePresentationCoreOptions,
-} from './core.js';
+import { renderChartToDataUrl, PLACEHOLDER_IMAGE } from './render-charts-browser.js';
+import { generatePresentationCore, type GeneratePresentationCoreOptions } from './core.js';
 
 export type BrowserGeneratePresentationOptions = GeneratePresentationCoreOptions;
 

--- a/packages/core/src/generator/core.ts
+++ b/packages/core/src/generator/core.ts
@@ -66,13 +66,8 @@ export async function generatePresentationCore(
   chartContext: ChartRenderingContext,
   options?: GeneratePresentationCoreOptions,
 ): Promise<string> {
-  const {
-    metadata,
-    students,
-    classAttendance,
-    failureStatistics,
-    aggregateGradeDistribution,
-  } = data;
+  const { metadata, students, classAttendance, failureStatistics, aggregateGradeDistribution } =
+    data;
 
   // Calculate analytics
   const classAverage = calculateClassAverage(students);
@@ -104,12 +99,11 @@ export async function generatePresentationCore(
     }
   };
 
-  const [subjectChartImage, studentChartImage, aggregateGradesChartImage] =
-    await Promise.all([
-      renderChart(subjectChartConfig, 'subject averages'),
-      renderChart(studentChartConfig, 'student averages'),
-      renderChart(aggregateGradesChartConfig, 'aggregate grades'),
-    ]);
+  const [subjectChartImage, studentChartImage, aggregateGradesChartImage] = await Promise.all([
+    renderChart(subjectChartConfig, 'subject averages'),
+    renderChart(studentChartConfig, 'student averages'),
+    renderChart(aggregateGradesChartConfig, 'aggregate grades'),
+  ]);
 
   // Convert grade distribution to template-friendly format
   const gradeDistribution: GradeDistributionRow[] | null =
@@ -143,10 +137,7 @@ export async function generatePresentationCore(
       failureStatistics,
     };
     const { generateConclusions } = await import('../ai/index.js');
-    aiConclusionsText = await generateConclusions(
-      analyticsResult,
-      options.geminiApiKey,
-    );
+    aiConclusionsText = await generateConclusions(analyticsResult, options.geminiApiKey);
   }
 
   // Get top students (4.75+ average) sorted by average desc, then number asc

--- a/packages/core/src/generator/index.test.ts
+++ b/packages/core/src/generator/index.test.ts
@@ -365,10 +365,7 @@ describe('generatePresentation', () => {
       await generatePresentation(data, { onChartRenderError: errorCallback });
 
       expect(errorCallback).toHaveBeenCalled();
-      expect(errorCallback).toHaveBeenCalledWith(
-        expect.any(String),
-        expect.any(Error),
-      );
+      expect(errorCallback).toHaveBeenCalledWith(expect.any(String), expect.any(Error));
 
       vi.restoreAllMocks();
     });

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -1,9 +1,6 @@
 import type { ClassData } from '../types/index.js';
 import { renderChartToDataUrl, PLACEHOLDER_IMAGE } from './render-charts.js';
-import {
-  generatePresentationCore,
-  type GeneratePresentationCoreOptions,
-} from './core.js';
+import { generatePresentationCore, type GeneratePresentationCoreOptions } from './core.js';
 
 export type GeneratePresentationOptions = GeneratePresentationCoreOptions;
 

--- a/packages/core/src/generator/render-charts-browser.test.ts
+++ b/packages/core/src/generator/render-charts-browser.test.ts
@@ -21,8 +21,6 @@ describe('render-charts-browser module', () => {
       },
     };
 
-    await expect(renderChartToDataUrl(config)).rejects.toThrow(
-      'requires a browser environment',
-    );
+    await expect(renderChartToDataUrl(config)).rejects.toThrow('requires a browser environment');
   });
 });

--- a/packages/core/src/generator/render-charts-browser.ts
+++ b/packages/core/src/generator/render-charts-browser.ts
@@ -17,9 +17,7 @@ export async function renderChartToDataUrl<T extends string>(
   config: ChartConfig<T>,
 ): Promise<string> {
   if (typeof document === 'undefined') {
-    throw new Error(
-      'renderChartToDataUrl requires a browser environment with DOM access',
-    );
+    throw new Error('renderChartToDataUrl requires a browser environment with DOM access');
   }
 
   const canvas = document.createElement('canvas');

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -13,7 +13,4 @@ export { generatePresentation } from './generator/index.js';
 export type { GeneratePresentationOptions } from './generator/index.js';
 
 // Node.js chart renderer
-export {
-  renderChartToDataUrl,
-  PLACEHOLDER_IMAGE,
-} from './generator/render-charts.js';
+export { renderChartToDataUrl, PLACEHOLDER_IMAGE } from './generator/render-charts.js';

--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -3,10 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Generator prezentacji z ocenami dla zebrań z rodzicami. Przetwarzanie lokalne w przeglądarce." />
+    <meta
+      name="description"
+      content="Generator prezentacji z ocenami dla zebrań z rodzicami. Przetwarzanie lokalne w przeglądarce."
+    />
     <meta name="theme-color" content="#2563eb" />
     <meta property="og:title" content="Klassroom - Generator prezentacji z ocenami" />
-    <meta property="og:description" content="Generator prezentacji z ocenami dla zebrań z rodzicami. Przetwarzanie lokalne w przeglądarce." />
+    <meta
+      property="og:description"
+      content="Generator prezentacji z ocenami dla zebrań z rodzicami. Przetwarzanie lokalne w przeglądarce."
+    />
     <meta property="og:image" content="https://klassroom.graczyk.dev/apple-touch-icon.png" />
     <meta property="og:type" content="website" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
@@ -25,7 +31,12 @@
       <p class="page-footer__links">
         <a href="/polityka-prywatnosci.html">Polityka prywatności</a>
         <span class="page-footer__separator" aria-hidden="true">·</span>
-        <a href="https://github.com/bitcraft-apps/klassroom" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a
+          href="https://github.com/bitcraft-apps/klassroom"
+          target="_blank"
+          rel="noopener noreferrer"
+          >GitHub</a
+        >
       </p>
     </footer>
     <script type="module" src="/src/main.ts"></script>

--- a/packages/web/public/polityka-prywatnosci.html
+++ b/packages/web/public/polityka-prywatnosci.html
@@ -10,7 +10,10 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Polityka prywatności aplikacji Klassroom - informacje o przetwarzaniu danych zgodnie z RODO" />
+    <meta
+      name="description"
+      content="Polityka prywatności aplikacji Klassroom - informacje o przetwarzaniu danych zgodnie z RODO"
+    />
     <meta name="theme-color" content="#2563eb" />
     <link rel="icon" href="/favicon.ico" sizes="32x32" />
     <link rel="icon" href="/icon.svg" type="image/svg+xml" />
@@ -31,11 +34,21 @@
         --space-8: 2rem;
       }
 
-      *, *::before, *::after { box-sizing: border-box; }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
 
       body {
         margin: 0;
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        font-family:
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          'Segoe UI',
+          Roboto,
+          sans-serif;
         font-size: 1rem;
         line-height: 1.5;
         color: var(--color-text);
@@ -154,12 +167,24 @@
       }
 
       @media (min-width: 640px) {
-        .page-header { padding: var(--space-6); }
-        .page-header__title { font-size: 1.875rem; }
-        .page-header__subtitle { font-size: 1rem; }
-        .content { padding: var(--space-8) var(--space-6); }
-        .page-footer { padding: var(--space-6); }
-        .page-footer__links { font-size: 0.875rem; }
+        .page-header {
+          padding: var(--space-6);
+        }
+        .page-header__title {
+          font-size: 1.875rem;
+        }
+        .page-header__subtitle {
+          font-size: 1rem;
+        }
+        .content {
+          padding: var(--space-8) var(--space-6);
+        }
+        .page-footer {
+          padding: var(--space-6);
+        }
+        .page-footer__links {
+          font-size: 0.875rem;
+        }
       }
     </style>
   </head>
@@ -171,50 +196,49 @@
 
     <main class="content">
       <p class="scope-notice">
-        <strong>Zakres:</strong> Ta polityka prywatności dotyczy wyłącznie oficjalnej
-        instancji aplikacji dostępnej pod adresem
-        <a href="https://klassroom.bitcraft.pl">klassroom.bitcraft.pl</a>.
-        Jeśli korzystasz z innej instancji, skontaktuj się z jej operatorem.
+        <strong>Zakres:</strong> Ta polityka prywatności dotyczy wyłącznie oficjalnej instancji
+        aplikacji dostępnej pod adresem
+        <a href="https://klassroom.bitcraft.pl">klassroom.bitcraft.pl</a>. Jeśli korzystasz z innej
+        instancji, skontaktuj się z jej operatorem.
       </p>
 
       <p><em>Ostatnia aktualizacja: 16 stycznia 2026</em></p>
 
       <div class="notice">
         <p>
-          <strong>Ważna informacja:</strong> Klassroom to oprogramowanie działające
-          wyłącznie lokalnie w przeglądarce internetowej. Bitcraft Apps udostępnia
-          kod aplikacji i hosting strony internetowej, ale <strong>nie przetwarza
-          danych osobowych z plików XLSX</strong> przesyłanych przez użytkowników –
-          dane te nigdy nie opuszczają urządzenia użytkownika.
+          <strong>Ważna informacja:</strong> Klassroom to oprogramowanie działające wyłącznie
+          lokalnie w przeglądarce internetowej. Bitcraft Apps udostępnia kod aplikacji i hosting
+          strony internetowej, ale
+          <strong>nie przetwarza danych osobowych z plików XLSX</strong> przesyłanych przez
+          użytkowników – dane te nigdy nie opuszczają urządzenia użytkownika.
         </p>
         <p>
-          Nauczyciel lub szkoła korzystająca z aplikacji jest administratorem
-          przetwarzanych przez siebie danych uczniów i ponosi odpowiedzialność
-          za zgodność z RODO.
+          Nauczyciel lub szkoła korzystająca z aplikacji jest administratorem przetwarzanych przez
+          siebie danych uczniów i ponosi odpowiedzialność za zgodność z RODO.
         </p>
       </div>
 
       <h2>1. Administrator danych</h2>
       <p>
-        <strong>Dane techniczne (hosting):</strong> Administratorem danych technicznych
-        związanych z korzystaniem ze strony internetowej (adresy IP, informacje o przeglądarce)
-        jest Szymon Graczyk, prowadzący jednoosobową działalność gospodarczą Bitcraft
-        (NIP: 6422997504, REGON: 243276930). Pełne dane rejestrowe są dostępne w
-        <a href="https://aplikacja.ceidg.gov.pl" target="_blank" rel="noopener noreferrer">CEIDG</a>.
-        Kontakt w sprawach ochrony danych: <a href="mailto:szymon@graczyk.dev">szymon@graczyk.dev</a>.
+        <strong>Dane techniczne (hosting):</strong> Administratorem danych technicznych związanych z
+        korzystaniem ze strony internetowej (adresy IP, informacje o przeglądarce) jest Szymon
+        Graczyk, prowadzący jednoosobową działalność gospodarczą Bitcraft (NIP: 6422997504, REGON:
+        243276930). Pełne dane rejestrowe są dostępne w
+        <a href="https://aplikacja.ceidg.gov.pl" target="_blank" rel="noopener noreferrer">CEIDG</a
+        >. Kontakt w sprawach ochrony danych:
+        <a href="mailto:szymon@graczyk.dev">szymon@graczyk.dev</a>.
       </p>
       <p>
-        <strong>Dane z plików XLSX (dane uczniów):</strong> Bitcraft Apps nie jest
-        administratorem tych danych. Pliki XLSX są przetwarzane wyłącznie lokalnie
-        w przeglądarce użytkownika i nigdy nie są przesyłane na serwery Bitcraft Apps.
-        Administratorem danych uczniów jest szkoła lub nauczyciel korzystający z aplikacji.
-        W sprawach dotyczących danych uczniów należy kontaktować się z właściwą szkołą.
+        <strong>Dane z plików XLSX (dane uczniów):</strong> Bitcraft Apps nie jest administratorem
+        tych danych. Pliki XLSX są przetwarzane wyłącznie lokalnie w przeglądarce użytkownika i
+        nigdy nie są przesyłane na serwery Bitcraft Apps. Administratorem danych uczniów jest szkoła
+        lub nauczyciel korzystający z aplikacji. W sprawach dotyczących danych uczniów należy
+        kontaktować się z właściwą szkołą.
       </p>
       <p>
-        Zgodnie z art. 37 RODO, wyznaczenie inspektora ochrony danych (IOD/DPO) nie jest
-        wymagane — administrator nie jest organem publicznym, a przetwarzanie danych nie
-        obejmuje regularnego monitorowania osób na dużą skalę ani przetwarzania szczególnych
-        kategorii danych.
+        Zgodnie z art. 37 RODO, wyznaczenie inspektora ochrony danych (IOD/DPO) nie jest wymagane —
+        administrator nie jest organem publicznym, a przetwarzanie danych nie obejmuje regularnego
+        monitorowania osób na dużą skalę ani przetwarzania szczególnych kategorii danych.
       </p>
 
       <h2>2. Jakie dane są przetwarzane</h2>
@@ -225,7 +249,10 @@
         <li>Data i czas dostępu do strony</li>
       </ul>
       <p><strong>Dane przetwarzane lokalnie przez użytkownika (w przeglądarce):</strong></p>
-      <p>Aplikacja Klassroom umożliwia przetwarzanie danych z plików XLSX eksportowanych z systemu Vulcan UONET+:</p>
+      <p>
+        Aplikacja Klassroom umożliwia przetwarzanie danych z plików XLSX eksportowanych z systemu
+        Vulcan UONET+:
+      </p>
       <ul>
         <li>Imiona i nazwiska uczniów</li>
         <li>Numery w dzienniku</li>
@@ -235,90 +262,98 @@
         <li>Dane o frekwencji klasy</li>
       </ul>
       <p>
-        <strong>Bitcraft Apps nie ma dostępu do powyższych danych uczniów</strong> –
-        są one przetwarzane wyłącznie na urządzeniu użytkownika.
+        <strong>Bitcraft Apps nie ma dostępu do powyższych danych uczniów</strong> – są one
+        przetwarzane wyłącznie na urządzeniu użytkownika.
       </p>
 
       <h2>3. Gdzie dane są przetwarzane</h2>
       <p>
-        <strong>Dane techniczne:</strong> Przetwarzane przez Cloudflare na serwerach
-        zlokalizowanych globalnie (szczegóły w sekcji 12).
+        <strong>Dane techniczne:</strong> Przetwarzane przez Cloudflare na serwerach zlokalizowanych
+        globalnie (szczegóły w sekcji 12).
       </p>
       <p>
         <strong>Dane z plików XLSX:</strong> Przetwarzane wyłącznie lokalnie w przeglądarce
-        użytkownika. Plik XLSX nigdy nie jest wysyłany na żaden serwer. Aplikacja działa
-        w całości po stronie klienta (w przeglądarce) i nie przesyła danych osobowych
-        uczniów przez internet.
+        użytkownika. Plik XLSX nigdy nie jest wysyłany na żaden serwer. Aplikacja działa w całości
+        po stronie klienta (w przeglądarce) i nie przesyła danych osobowych uczniów przez internet.
       </p>
 
       <h2>4. Cel przetwarzania</h2>
       <p>
-        <strong>Dane techniczne:</strong> Przetwarzane w celu zapewnienia bezpieczeństwa
-        i prawidłowego funkcjonowania strony internetowej.
+        <strong>Dane techniczne:</strong> Przetwarzane w celu zapewnienia bezpieczeństwa i
+        prawidłowego funkcjonowania strony internetowej.
       </p>
       <p>
         <strong>Dane z plików XLSX:</strong> Oprogramowanie Klassroom umożliwia użytkownikom
-        (nauczycielom) generowanie prezentacji HTML z podsumowaniem ocen klasy, przeznaczonych
-        do wyświetlenia podczas zebrań z rodzicami. Cel przetwarzania określa użytkownik
+        (nauczycielom) generowanie prezentacji HTML z podsumowaniem ocen klasy, przeznaczonych do
+        wyświetlenia podczas zebrań z rodzicami. Cel przetwarzania określa użytkownik
         (nauczyciel/szkoła) jako administrator tych danych.
       </p>
 
       <h2>5. Podstawa prawna</h2>
       <p>
-        <strong>Dane techniczne:</strong> Podstawą prawną przetwarzania danych technicznych
-        przez Bitcraft Apps jest prawnie uzasadniony interes (art. 6 ust. 1 lit. f RODO)
-        polegający na zapewnieniu bezpieczeństwa i prawidłowego funkcjonowania strony internetowej.
+        <strong>Dane techniczne:</strong> Podstawą prawną przetwarzania danych technicznych przez
+        Bitcraft Apps jest prawnie uzasadniony interes (art. 6 ust. 1 lit. f RODO) polegający na
+        zapewnieniu bezpieczeństwa i prawidłowego funkcjonowania strony internetowej.
       </p>
       <p>
-        <strong>Dane z plików XLSX:</strong> Bitcraft Apps nie przetwarza tych danych i nie jest
-        ich administratorem. Szkoły korzystające z aplikacji Klassroom przetwarzają dane uczniów
-        zazwyczaj na podstawie art. 6 ust. 1 lit. e RODO (zadanie realizowane w interesie publicznym)
-        w związku z przepisami prawa oświatowego. Użytkownik (nauczyciel/szkoła) jest odpowiedzialny
-        za posiadanie właściwej podstawy prawnej do przetwarzania danych uczniów.
+        <strong>Dane z plików XLSX:</strong> Bitcraft Apps nie przetwarza tych danych i nie jest ich
+        administratorem. Szkoły korzystające z aplikacji Klassroom przetwarzają dane uczniów
+        zazwyczaj na podstawie art. 6 ust. 1 lit. e RODO (zadanie realizowane w interesie
+        publicznym) w związku z przepisami prawa oświatowego. Użytkownik (nauczyciel/szkoła) jest
+        odpowiedzialny za posiadanie właściwej podstawy prawnej do przetwarzania danych uczniów.
       </p>
 
       <h2>6. Obowiązek podania danych</h2>
       <p>
-        <strong>Dane techniczne:</strong> Podanie danych technicznych (adres IP, informacje
-        o przeglądarce) jest wymogiem technicznym — dane te są automatycznie przesyłane
-        przez przeglądarkę podczas każdego połączenia ze stroną internetową. Bez tych danych
-        wyświetlenie strony nie jest możliwe.
+        <strong>Dane techniczne:</strong> Podanie danych technicznych (adres IP, informacje o
+        przeglądarce) jest wymogiem technicznym — dane te są automatycznie przesyłane przez
+        przeglądarkę podczas każdego połączenia ze stroną internetową. Bez tych danych wyświetlenie
+        strony nie jest możliwe.
       </p>
       <p>
-        <strong>Dane z plików XLSX:</strong> Korzystanie z aplikacji Klassroom i przetwarzanie
-        pliku XLSX jest całkowicie dobrowolne. Niepodanie tych danych oznacza jedynie
-        niemożność wygenerowania prezentacji z ocenami.
+        <strong>Dane z plików XLSX:</strong> Korzystanie z aplikacji Klassroom i przetwarzanie pliku
+        XLSX jest całkowicie dobrowolne. Niepodanie tych danych oznacza jedynie niemożność
+        wygenerowania prezentacji z ocenami.
       </p>
 
       <h2>7. Odbiorcy danych</h2>
       <p>
-        <strong>Dane techniczne:</strong> Mogą być przetwarzane przez dostawcę hostingu (Cloudflare) –
-        szczegóły w sekcji 12.
+        <strong>Dane techniczne:</strong> Mogą być przetwarzane przez dostawcę hostingu (Cloudflare)
+        – szczegóły w sekcji 12.
       </p>
       <p>
-        <strong>Dane z plików XLSX:</strong> Nie są udostępniane żadnym podmiotom, w tym Bitcraft Apps.
-        Plik XLSX i jego zawartość pozostają wyłącznie na urządzeniu użytkownika i nigdy nie opuszczają
-        przeglądarki.
+        <strong>Dane z plików XLSX:</strong> Nie są udostępniane żadnym podmiotom, w tym Bitcraft
+        Apps. Plik XLSX i jego zawartość pozostają wyłącznie na urządzeniu użytkownika i nigdy nie
+        opuszczają przeglądarki.
       </p>
 
       <h2>8. Dane w wygenerowanej prezentacji</h2>
       <p>
         Oprogramowanie Klassroom zostało zaprojektowane tak, aby wygenerowana prezentacja zawierała
-        <strong>wyłącznie numery uczniów w dzienniku, nigdy imiona ani nazwiska</strong>.
-        Dzięki temu prezentację można bezpiecznie wyświetlić podczas zebrania z rodzicami,
-        zachowując prywatność poszczególnych uczniów.
+        <strong>wyłącznie numery uczniów w dzienniku, nigdy imiona ani nazwiska</strong>. Dzięki
+        temu prezentację można bezpiecznie wyświetlić podczas zebrania z rodzicami, zachowując
+        prywatność poszczególnych uczniów.
       </p>
 
       <h2>9. Okres przechowywania danych</h2>
       <p>
         <strong>Dane techniczne:</strong> Przechowywane przez Cloudflare zgodnie z ich
-        <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener noreferrer">polityką retencji</a>.
+        <a
+          href="https://www.cloudflare.com/privacypolicy/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >polityką retencji</a
+        >.
       </p>
       <p>
         <strong>Dane z plików XLSX:</strong> Przechowywane wyłącznie w pamięci przeglądarki podczas
-        sesji użytkowania aplikacji. <strong>Po zamknięciu karty przeglądarki lub strony wszystkie
-        dane są automatycznie usuwane.</strong> Aplikacja nie zapisuje danych w localStorage,
-        IndexedDB ani żadnym innym trwałym magazynie danych.
+        sesji użytkowania aplikacji.
+        <strong
+          >Po zamknięciu karty przeglądarki lub strony wszystkie dane są automatycznie
+          usuwane.</strong
+        >
+        Aplikacja nie zapisuje danych w localStorage, IndexedDB ani żadnym innym trwałym magazynie
+        danych.
       </p>
 
       <h2>10. Prawa użytkownika</h2>
@@ -332,42 +367,50 @@
         <li>Prawo do wniesienia sprzeciwu (art. 21 RODO)</li>
       </ul>
       <p>
-        <strong>W odniesieniu do danych technicznych:</strong> W celu realizacji powyższych praw
-        w zakresie danych przetwarzanych przez Bitcraft Apps (adresy IP, dane przeglądarki),
-        prosimy o kontakt na adres e-mail wskazany w sekcji 1.
+        <strong>W odniesieniu do danych technicznych:</strong> W celu realizacji powyższych praw w
+        zakresie danych przetwarzanych przez Bitcraft Apps (adresy IP, dane przeglądarki), prosimy o
+        kontakt na adres e-mail wskazany w sekcji 1.
       </p>
       <p>
-        <strong>W odniesieniu do danych uczniów z plików XLSX:</strong> Bitcraft Apps nie ma
-        dostępu do tych danych – są one przetwarzane wyłącznie lokalnie na urządzeniu użytkownika.
-        W celu realizacji praw dotyczących danych uczniów należy skontaktować się z administratorem
-        tych danych, czyli szkołą. Użytkownik może również samodzielnie usunąć dane poprzez
-        zamknięcie strony aplikacji.
+        <strong>W odniesieniu do danych uczniów z plików XLSX:</strong> Bitcraft Apps nie ma dostępu
+        do tych danych – są one przetwarzane wyłącznie lokalnie na urządzeniu użytkownika. W celu
+        realizacji praw dotyczących danych uczniów należy skontaktować się z administratorem tych
+        danych, czyli szkołą. Użytkownik może również samodzielnie usunąć dane poprzez zamknięcie
+        strony aplikacji.
       </p>
       <p>
-        Przysługuje Państwu również prawo do wniesienia skargi do organu nadzorczego – Prezesa Urzędu
-        Ochrony Danych Osobowych (ul. Stawki 2, 00-193 Warszawa,
+        Przysługuje Państwu również prawo do wniesienia skargi do organu nadzorczego – Prezesa
+        Urzędu Ochrony Danych Osobowych (ul. Stawki 2, 00-193 Warszawa,
         <a href="https://uodo.gov.pl" target="_blank" rel="noopener noreferrer">uodo.gov.pl</a>).
       </p>
 
       <h2>11. Pliki cookie i Service Worker</h2>
       <p>
-        Aplikacja nie wykorzystuje plików cookie do śledzenia użytkowników ani w celach marketingowych.
-        Service Worker jest używany wyłącznie do buforowania plików aplikacji (HTML, CSS, JavaScript)
-        w celu umożliwienia działania offline. <strong>Service Worker nie przechowuje żadnych danych osobowych.</strong>
+        Aplikacja nie wykorzystuje plików cookie do śledzenia użytkowników ani w celach
+        marketingowych. Service Worker jest używany wyłącznie do buforowania plików aplikacji (HTML,
+        CSS, JavaScript) w celu umożliwienia działania offline.
+        <strong>Service Worker nie przechowuje żadnych danych osobowych.</strong>
       </p>
 
       <h2>12. Hosting i przekazywanie danych</h2>
       <p>
         Aplikacja jest hostowana na platformie Cloudflare Pages. Cloudflare może zbierać podstawowe
-        dane techniczne (adresy IP, informacje o przeglądarce) zgodnie ze swoją polityką prywatności:
-        <a href="https://www.cloudflare.com/privacypolicy/" target="_blank" rel="noopener noreferrer">cloudflare.com/privacypolicy</a>.
-        Cloudflare może przekazywać te dane techniczne do państw trzecich (w tym USA) na podstawie
-        standardowych klauzul umownych.
+        dane techniczne (adresy IP, informacje o przeglądarce) zgodnie ze swoją polityką
+        prywatności:
+        <a
+          href="https://www.cloudflare.com/privacypolicy/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >cloudflare.com/privacypolicy</a
+        >. Cloudflare może przekazywać te dane techniczne do państw trzecich (w tym USA) na
+        podstawie standardowych klauzul umownych.
       </p>
       <p>
-        <strong>Należy podkreślić, że dane z plików XLSX (dane uczniów) nie są w żaden sposób przesyłane
-        do Cloudflare ani żadnego innego serwera</strong> – przetwarzanie odbywa się wyłącznie lokalnie
-        w przeglądarce.
+        <strong
+          >Należy podkreślić, że dane z plików XLSX (dane uczniów) nie są w żaden sposób przesyłane
+          do Cloudflare ani żadnego innego serwera</strong
+        >
+        – przetwarzanie odbywa się wyłącznie lokalnie w przeglądarce.
       </p>
 
       <h2>13. Zautomatyzowane podejmowanie decyzji</h2>
@@ -379,11 +422,15 @@
       <h2>14. Charakter dokumentu</h2>
       <p>
         Oprogramowanie Klassroom jest udostępniane na
-        <a href="https://github.com/bitcraft-apps/klassroom/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">licencji MIT</a>,
-        bez jakichkolwiek gwarancji. Niniejsza polityka prywatności ma charakter informacyjny
-        i opisuje aktualne praktyki dotyczące prywatności. Nie stanowi ona porady prawnej.
-        W przypadku wątpliwości dotyczących zgodności z RODO, zalecamy konsultację z prawnikiem
-        lub inspektorem ochrony danych.
+        <a
+          href="https://github.com/bitcraft-apps/klassroom/blob/main/LICENSE"
+          target="_blank"
+          rel="noopener noreferrer"
+          >licencji MIT</a
+        >, bez jakichkolwiek gwarancji. Niniejsza polityka prywatności ma charakter informacyjny i
+        opisuje aktualne praktyki dotyczące prywatności. Nie stanowi ona porady prawnej. W przypadku
+        wątpliwości dotyczących zgodności z RODO, zalecamy konsultację z prawnikiem lub inspektorem
+        ochrony danych.
       </p>
     </main>
 
@@ -391,7 +438,12 @@
       <p class="page-footer__links">
         <a href="/">Powrót do aplikacji</a>
         <span class="page-footer__separator" aria-hidden="true">·</span>
-        <a href="https://github.com/bitcraft-apps/klassroom" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <a
+          href="https://github.com/bitcraft-apps/klassroom"
+          target="_blank"
+          rel="noopener noreferrer"
+          >GitHub</a
+        >
       </p>
     </footer>
   </body>

--- a/packages/web/src/components/file-upload.test.ts
+++ b/packages/web/src/components/file-upload.test.ts
@@ -180,7 +180,11 @@ describe('createFileUpload', () => {
     it('accepts valid XLSX file', () => {
       createFileUpload(container, events);
 
-      const file = createFile('test.xlsx', 1024, 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+      const file = createFile(
+        'test.xlsx',
+        1024,
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      );
       const dropZone = container.querySelector('.file-upload') as HTMLElement;
 
       dropZone.dispatchEvent(

--- a/packages/web/src/components/file-upload.ts
+++ b/packages/web/src/components/file-upload.ts
@@ -64,10 +64,7 @@ function validateFile(file: File): string | null {
  * @param container - Parent element to mount the component into
  * @param events - Callback handlers for file selection and errors
  */
-export function createFileUpload(
-  container: HTMLElement,
-  events: FileUploadEvents,
-): void {
+export function createFileUpload(container: HTMLElement, events: FileUploadEvents): void {
   // Create DOM structure
   const errorId = `file-upload-error-${Date.now()}`;
 

--- a/packages/web/src/components/generator.test.ts
+++ b/packages/web/src/components/generator.test.ts
@@ -2,11 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import {
-  createGenerator,
-  type GeneratorData,
-  type GeneratorEvents,
-} from './generator.js';
+import { createGenerator, type GeneratorData, type GeneratorEvents } from './generator.js';
 import type { ClassPeriod, StudentNumber } from '@klassroom/core';
 
 // Mock @klassroom/core/browser
@@ -98,9 +94,7 @@ describe('createGenerator', () => {
     it('creates complete section (hidden initially)', () => {
       createGenerator(container, data, events);
 
-      const complete = container.querySelector(
-        '.generator__complete',
-      ) as HTMLElement;
+      const complete = container.querySelector('.generator__complete') as HTMLElement;
       expect(complete).toBeTruthy();
       expect(complete.hidden).toBe(true);
     });
@@ -169,9 +163,7 @@ describe('createGenerator', () => {
     });
 
     it('focuses retry button after generation error', async () => {
-      vi.mocked(generatePresentationBrowser).mockRejectedValue(
-        new Error('Failed'),
-      );
+      vi.mocked(generatePresentationBrowser).mockRejectedValue(new Error('Failed'));
 
       createGenerator(container, data, events);
 
@@ -192,9 +184,7 @@ describe('createGenerator', () => {
 
       await vi.runAllTimersAsync();
 
-      const errorText = container.querySelector(
-        '.generator__error-text',
-      ) as HTMLElement;
+      const errorText = container.querySelector('.generator__error-text') as HTMLElement;
       expect(errorText.title).toContain('Long error message for accessibility');
     });
   });
@@ -220,39 +210,29 @@ describe('createGenerator', () => {
 
       await vi.runAllTimersAsync();
 
-      const btn = container.querySelector(
-        '.generator__complete .generator__button--primary',
-      );
+      const btn = container.querySelector('.generator__complete .generator__button--primary');
       expect(btn?.textContent).toBe('Generuj kolejną');
     });
 
     it('displays retry button text in Polish', async () => {
-      vi.mocked(generatePresentationBrowser).mockRejectedValue(
-        new Error('Failed'),
-      );
+      vi.mocked(generatePresentationBrowser).mockRejectedValue(new Error('Failed'));
 
       createGenerator(container, data, events);
 
       await vi.runAllTimersAsync();
 
-      const btn = container.querySelector(
-        '.generator__error .generator__button--primary',
-      );
+      const btn = container.querySelector('.generator__error .generator__button--primary');
       expect(btn?.textContent).toBe('Spróbuj ponownie');
     });
 
     it('displays error message in Polish', async () => {
-      vi.mocked(generatePresentationBrowser).mockRejectedValue(
-        new Error('Failed'),
-      );
+      vi.mocked(generatePresentationBrowser).mockRejectedValue(new Error('Failed'));
 
       createGenerator(container, data, events);
 
       await vi.runAllTimersAsync();
 
-      expect(container.textContent).toContain(
-        'Wystąpił błąd podczas generowania prezentacji',
-      );
+      expect(container.textContent).toContain('Wystąpił błąd podczas generowania prezentacji');
     });
 
     it('updates progress step to preparing before download', async () => {
@@ -285,10 +265,7 @@ describe('createGenerator', () => {
 
       await vi.runAllTimersAsync();
 
-      expect(generatePresentationFilename).toHaveBeenCalledWith(
-        '3A',
-        '2024/2025 - Semestr 1',
-      );
+      expect(generatePresentationFilename).toHaveBeenCalledWith('3A', '2024/2025 - Semestr 1');
     });
 
     it('downloads file on successful generation', async () => {
@@ -304,12 +281,8 @@ describe('createGenerator', () => {
 
       await vi.runAllTimersAsync();
 
-      const progress = container.querySelector(
-        '.generator__progress',
-      ) as HTMLElement;
-      const complete = container.querySelector(
-        '.generator__complete',
-      ) as HTMLElement;
+      const progress = container.querySelector('.generator__progress') as HTMLElement;
+      const complete = container.querySelector('.generator__complete') as HTMLElement;
 
       expect(progress.hidden).toBe(true);
       expect(complete.hidden).toBe(false);
@@ -326,17 +299,13 @@ describe('createGenerator', () => {
 
   describe('error handling', () => {
     it('shows error section on generation failure', async () => {
-      vi.mocked(generatePresentationBrowser).mockRejectedValue(
-        new Error('Generation failed'),
-      );
+      vi.mocked(generatePresentationBrowser).mockRejectedValue(new Error('Generation failed'));
 
       createGenerator(container, data, events);
 
       await vi.runAllTimersAsync();
 
-      const progress = container.querySelector(
-        '.generator__progress',
-      ) as HTMLElement;
+      const progress = container.querySelector('.generator__progress') as HTMLElement;
       const error = container.querySelector('.generator__error') as HTMLElement;
 
       expect(progress.hidden).toBe(true);
@@ -344,9 +313,7 @@ describe('createGenerator', () => {
     });
 
     it('includes error message detail', async () => {
-      vi.mocked(generatePresentationBrowser).mockRejectedValue(
-        new Error('Chart rendering failed'),
-      );
+      vi.mocked(generatePresentationBrowser).mockRejectedValue(new Error('Chart rendering failed'));
 
       createGenerator(container, data, events);
 
@@ -356,9 +323,7 @@ describe('createGenerator', () => {
     });
 
     it('does not call download on error', async () => {
-      vi.mocked(generatePresentationBrowser).mockRejectedValue(
-        new Error('Failed'),
-      );
+      vi.mocked(generatePresentationBrowser).mockRejectedValue(new Error('Failed'));
 
       createGenerator(container, data, events);
 
@@ -374,13 +339,9 @@ describe('createGenerator', () => {
 
       await vi.runAllTimersAsync();
 
-      const errorText = container.querySelector(
-        '.generator__error-text',
-      ) as HTMLElement;
+      const errorText = container.querySelector('.generator__error-text') as HTMLElement;
       // Empty message falls back to generic Polish error text
-      expect(errorText.textContent).toBe(
-        'Wystąpił błąd podczas generowania prezentacji',
-      );
+      expect(errorText.textContent).toBe('Wystąpił błąd podczas generowania prezentacji');
       // No title attribute when message is empty (no tooltip needed)
       expect(errorText.title).toBe('');
     });
@@ -392,12 +353,8 @@ describe('createGenerator', () => {
 
       await vi.runAllTimersAsync();
 
-      const errorText = container.querySelector(
-        '.generator__error-text',
-      ) as HTMLElement;
-      expect(errorText.textContent).toBe(
-        'Wystąpił błąd podczas generowania prezentacji',
-      );
+      const errorText = container.querySelector('.generator__error-text') as HTMLElement;
+      expect(errorText.textContent).toBe('Wystąpił błąd podczas generowania prezentacji');
     });
   });
 
@@ -452,9 +409,7 @@ describe('createGenerator', () => {
       btn.click();
 
       // Progress should be visible again
-      const progress = container.querySelector(
-        '.generator__progress',
-      ) as HTMLElement;
+      const progress = container.querySelector('.generator__progress') as HTMLElement;
       const error = container.querySelector('.generator__error') as HTMLElement;
 
       expect(progress.hidden).toBe(false);
@@ -513,12 +468,8 @@ describe('createGenerator', () => {
       await vi.runAllTimersAsync();
 
       // Progress should still be visible (not transitioned to complete)
-      const progress = container.querySelector(
-        '.generator__progress',
-      ) as HTMLElement;
-      const complete = container.querySelector(
-        '.generator__complete',
-      ) as HTMLElement;
+      const progress = container.querySelector('.generator__progress') as HTMLElement;
+      const complete = container.querySelector('.generator__complete') as HTMLElement;
 
       expect(progress.hidden).toBe(false);
       expect(complete.hidden).toBe(true);
@@ -546,9 +497,7 @@ describe('createGenerator', () => {
       await vi.runAllTimersAsync();
 
       // Progress should still be visible (not transitioned to error)
-      const progress = container.querySelector(
-        '.generator__progress',
-      ) as HTMLElement;
+      const progress = container.querySelector('.generator__progress') as HTMLElement;
       const error = container.querySelector('.generator__error') as HTMLElement;
 
       expect(progress.hidden).toBe(false);

--- a/packages/web/src/components/generator.ts
+++ b/packages/web/src/components/generator.ts
@@ -5,10 +5,7 @@
 
 import { generatePresentationBrowser } from '@klassroom/core/browser';
 import type { ClassData } from '@klassroom/core';
-import {
-  downloadFile,
-  generatePresentationFilename,
-} from '../utils/download.js';
+import { downloadFile, generatePresentationFilename } from '../utils/download.js';
 import './generator.css';
 
 // Polish UI text

--- a/packages/web/src/components/preview.test.ts
+++ b/packages/web/src/components/preview.test.ts
@@ -2,11 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import {
-  createPreview,
-  type PreviewData,
-  type PreviewEvents,
-} from './preview.js';
+import { createPreview, type PreviewData, type PreviewEvents } from './preview.js';
 
 describe('createPreview', () => {
   let container: HTMLElement;
@@ -192,9 +188,7 @@ describe('createPreview', () => {
 
       createPreview(container, data, events);
 
-      const warningsSection = container.querySelector(
-        '.preview__section--warnings',
-      );
+      const warningsSection = container.querySelector('.preview__section--warnings');
       expect(warningsSection).toBeNull();
     });
 
@@ -203,9 +197,7 @@ describe('createPreview', () => {
 
       createPreview(container, data, events);
 
-      const warningsSection = container.querySelector(
-        '.preview__section--warnings',
-      );
+      const warningsSection = container.querySelector('.preview__section--warnings');
       expect(warningsSection).toBeTruthy();
     });
 
@@ -231,9 +223,7 @@ describe('createPreview', () => {
     it('calls onGenerate when generate button clicked', () => {
       createPreview(container, data, events);
 
-      const btn = container.querySelector(
-        '.preview__button--primary',
-      ) as HTMLButtonElement;
+      const btn = container.querySelector('.preview__button--primary') as HTMLButtonElement;
       btn.click();
 
       expect(events.onGenerate).toHaveBeenCalledTimes(1);
@@ -242,9 +232,7 @@ describe('createPreview', () => {
     it('calls onCancel when cancel button clicked', () => {
       createPreview(container, data, events);
 
-      const btn = container.querySelector(
-        '.preview__button--secondary',
-      ) as HTMLButtonElement;
+      const btn = container.querySelector('.preview__button--secondary') as HTMLButtonElement;
       btn.click();
 
       expect(events.onCancel).toHaveBeenCalledTimes(1);
@@ -257,9 +245,7 @@ describe('createPreview', () => {
 
       createPreview(container, data, events);
 
-      const btn = container.querySelector(
-        '.preview__button--primary',
-      ) as HTMLButtonElement;
+      const btn = container.querySelector('.preview__button--primary') as HTMLButtonElement;
       expect(btn.disabled).toBe(true);
     });
 
@@ -268,9 +254,7 @@ describe('createPreview', () => {
 
       createPreview(container, data, events);
 
-      const btn = container.querySelector(
-        '.preview__button--primary',
-      ) as HTMLButtonElement;
+      const btn = container.querySelector('.preview__button--primary') as HTMLButtonElement;
       expect(btn.disabled).toBe(false);
     });
 
@@ -279,9 +263,7 @@ describe('createPreview', () => {
 
       createPreview(container, data, events);
 
-      const btn = container.querySelector(
-        '.preview__button--primary',
-      ) as HTMLButtonElement;
+      const btn = container.querySelector('.preview__button--primary') as HTMLButtonElement;
       btn.click();
 
       expect(events.onGenerate).not.toHaveBeenCalled();

--- a/packages/web/src/styles/main.css
+++ b/packages/web/src/styles/main.css
@@ -46,7 +46,12 @@
 
 body {
   margin: 0;
-  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
     sans-serif;
   font-size: 1rem;
   line-height: 1.5;

--- a/packages/web/src/utils/download.test.ts
+++ b/packages/web/src/utils/download.test.ts
@@ -94,9 +94,7 @@ describe('extractPeriodId', () => {
   });
 
   it('handles period with extra text', () => {
-    expect(extractPeriodId('2024/2025 rok szkolny - Semestr 1 oceny')).toBe(
-      'semestr1',
-    );
+    expect(extractPeriodId('2024/2025 rok szkolny - Semestr 1 oceny')).toBe('semestr1');
   });
 });
 
@@ -107,10 +105,7 @@ describe('generatePresentationFilename', () => {
   });
 
   it('sanitizes class name', () => {
-    const result = generatePresentationFilename(
-      'Klasa 3A',
-      '2024/2025 - Semestr 1',
-    );
+    const result = generatePresentationFilename('Klasa 3A', '2024/2025 - Semestr 1');
     expect(result).toBe('Klasa_3A_semestr1.html');
   });
 

--- a/packages/web/src/utils/download.ts
+++ b/packages/web/src/utils/download.ts
@@ -47,10 +47,7 @@ export function extractPeriodId(period: string): string {
  * @param period - Period string from ClassMetadata
  * @returns Generated filename
  */
-export function generatePresentationFilename(
-  className: string,
-  period: string,
-): string {
+export function generatePresentationFilename(className: string, period: string): string {
   const sanitizedClass = sanitizeFilename(className);
   const periodId = extractPeriodId(period);
   return `${sanitizedClass}_${periodId}.html`;


### PR DESCRIPTION
## Summary

Applies consistent formatting across the codebase using `pnpm format` (prettier --write .).

## Changes

- **20 files** reformatted
- **No functional changes** - purely whitespace, indentation, and line break adjustments
- All tests pass (411/411)

### Files formatted

| Package | Files |
|---------|-------|
| `@klassroom/cli` | 1 test file |
| `@klassroom/core` | 9 files (browser entry, generator module) |
| `@klassroom/web` | 10 files (components, utils, HTML, CSS) |

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (411 tests)
- [x] `pnpm prettier --check .` shows no issues

🤖 Generated with [Claude Code](https://claude.ai/code)