### PR TITLE
feat(web): add Bitcraft author branding to footer

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -38,6 +38,16 @@
           >GitHub</a
         >
       </p>
+      <a
+        class="page-footer__author"
+        href="https://github.com/bitcraft-apps"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Bitcraft Apps on GitHub"
+      >
+        <img src="/bitcraft-logo.svg" alt="Bitcraft" class="page-footer__logo page-footer__logo--mono" />
+        <img src="/bitcraft-logo-color.svg" alt="" class="page-footer__logo page-footer__logo--color" aria-hidden="true" />
+      </a>
     </footer>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/packages/web/public/bitcraft-logo-color.svg
+++ b/packages/web/public/bitcraft-logo-color.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="112 96 264 280" width="264" height="280" aria-label="Bitcraft">
+  <rect x="112" y="96" width="184" height="48" rx="24" fill="#556B2F"/>
+  <rect x="160" y="156" width="176" height="48" rx="24" fill="#6B8E23"/>
+  <rect x="112" y="216" width="144" height="40" rx="20" fill="#556B2F"/>
+  <rect x="160" y="268" width="216" height="48" rx="24" fill="#228B22"/>
+  <rect x="112" y="328" width="200" height="48" rx="24" fill="#556B2F"/>
+</svg>

--- a/packages/web/public/bitcraft-logo.svg
+++ b/packages/web/public/bitcraft-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="112 96 264 280" width="264" height="280" aria-label="Bitcraft">
+  <rect x="112" y="96" width="184" height="48" rx="24" fill="#1a1a1a"/>
+  <rect x="160" y="156" width="176" height="48" rx="24" fill="#444444"/>
+  <rect x="112" y="216" width="144" height="40" rx="20" fill="#1a1a1a"/>
+  <rect x="160" y="268" width="216" height="48" rx="24" fill="#666666"/>
+  <rect x="112" y="328" width="200" height="48" rx="24" fill="#1a1a1a"/>
+</svg>

--- a/packages/web/src/styles/main.css
+++ b/packages/web/src/styles/main.css
@@ -215,6 +215,45 @@ h2 {
   color: var(--color-border);
 }
 
+.page-footer__author {
+  display: inline-block;
+  position: relative;
+  margin-top: var(--space-3);
+}
+
+.page-footer__author:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.page-footer__logo {
+  height: 1.5rem;
+  width: auto;
+  transition: opacity 0.2s;
+}
+
+.page-footer__logo--mono {
+  opacity: 0.5;
+}
+
+.page-footer__logo--color {
+  position: absolute;
+  left: 0;
+  top: 0;
+  opacity: 0;
+}
+
+.page-footer__author:hover .page-footer__logo--mono,
+.page-footer__author:focus-visible .page-footer__logo--mono {
+  opacity: 0;
+}
+
+.page-footer__author:hover .page-footer__logo--color,
+.page-footer__author:focus-visible .page-footer__logo--color {
+  opacity: 1;
+}
+
 @media (min-width: 640px) {
   .page-footer {
     padding: var(--space-6);
@@ -223,6 +262,10 @@ h2 {
   .page-footer__text,
   .page-footer__links {
     font-size: 0.875rem;
+  }
+
+  .page-footer__logo {
+    height: 1.75rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add Bitcraft logo from the [brand repo](https://github.com/bitcraft-apps/brand) to the web app footer
- Logo links to the Bitcraft Apps GitHub organization
- Subtle hover effect and responsive sizing

## Test plan
- [ ] Verify logo appears in footer on desktop and mobile
- [ ] Verify logo links to https://github.com/bitcraft-apps
- [ ] Verify hover effect works (opacity transition)
- [ ] Check accessibility (focus outline visible on keyboard navigation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)