### PR TITLE
docs: adopt Simplified Technical English (ASD-STE100) for English prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,12 @@ Polish behavior grades map: wzorowe→exemplary, bardzo dobre→veryGood, dobre�
 ### Future: Librus Synergia Support
 
 Librus Synergia exports are not yet supported. We have no verified sample of the Librus format - it may or may not use the same sheet structure as Vulcan UONET+. If you have a Librus Synergia export file, please file an issue to help us add support.
+
+## Writing style
+
+English prose — docs, code comments, commit and PR text, issues, user-visible strings —
+follows [Simplified Technical English](https://www.asd-ste100.org/) (ASD-STE100): one
+meaning per word, active voice, imperative for instructions, simple tenses, one
+instruction per sentence (max 20 words), no jargon or metaphor. Code identifiers are exempt.
+
+Polish user-facing copy follows *prosta polszczyzna* instead ([jasnopis.pl](https://jasnopis.pl/), ISO 24495-1).


### PR DESCRIPTION
One paragraph in the agent file requiring [Simplified Technical English](https://www.asd-ste100.org/) (ASD-STE100) for English prose — docs, code comments, commit and PR text, issues, user-visible strings. Code identifiers are exempt.

Kept to the rules that actually change output rather than restating all 53; the standard is linked for the rest.

Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)